### PR TITLE
Add AdaptiveSearch and AdaptiveProbeFunc to journal package

### DIFF
--- a/journal/search.go
+++ b/journal/search.go
@@ -46,6 +46,83 @@ func Search[T any](
 	return 0, rec, ValueNotFoundError{}
 }
 
+// AdaptiveProbeFunc is a function that determines the next probe position for
+// an [AdaptiveSearch].
+//
+// i is the current search bracket — the half-open interval of journal
+// positions still under consideration.
+//
+// On the first call, hasPrev is false and prevPos and prevRec are zero values.
+// On subsequent calls, hasPrev is true and prevPos and prevRec hold the
+// position and record of the most recent probe.
+//
+// If found is true, the record at prevPos/prevRec is the target and next is
+// ignored. When hasPrev is false, found must be false.
+//
+// When found is false, next must be within i. When hasPrev is true, next must
+// differ from prevPos; the algorithm's behavior is undefined otherwise.
+type AdaptiveProbeFunc[T any] func(
+	ctx context.Context,
+	i Interval,
+	prevPos Position,
+	prevRec T,
+	hasPrev bool,
+) (next Position, found bool, err error)
+
+// AdaptiveSearch searches j within the interval i for a target record, using
+// fn to determine which position to probe at each iteration.
+//
+// Unlike [Search], which always probes the midpoint of the remaining interval,
+// AdaptiveSearch allows the caller to choose the next probe position based on
+// the content of the previously probed record. This makes it suitable for
+// implementing interpolation search and similar algorithms that use record
+// content to estimate where the target is likely to be.
+//
+// It returns a [ValueNotFoundError] if the target record is not found.
+func AdaptiveSearch[T any](
+	ctx context.Context,
+	j Journal[T],
+	i Interval,
+	fn AdaptiveProbeFunc[T],
+) (Position, T, error) {
+	var zero T
+
+	if i.IsEmpty() {
+		return 0, zero, ValueNotFoundError{}
+	}
+
+	pos, _, err := fn(ctx, i, 0, zero, false)
+	if err != nil {
+		return 0, zero, err
+	}
+
+	for !i.IsEmpty() {
+		rec, err := j.Get(ctx, pos)
+		if err != nil {
+			return 0, zero, err
+		}
+
+		next, found, err := fn(ctx, i, pos, rec, true)
+		if err != nil {
+			return 0, zero, err
+		}
+
+		if found {
+			return pos, rec, nil
+		}
+
+		if next > pos {
+			i.Begin = pos + 1
+		} else {
+			i.End = pos
+		}
+
+		pos = next
+	}
+
+	return 0, zero, ValueNotFoundError{}
+}
+
 // RangeFromSearchResult invokes fn for each record in the journal, in order,
 // beginning with the record within the interval i for which cmp() returns
 // zero.

--- a/journal/search.go
+++ b/journal/search.go
@@ -49,28 +49,24 @@ func Search[T any](
 // AdaptiveProbeFunc is a function that determines the next probe position for
 // an [AdaptiveSearch].
 //
-// i is the current search bracket — the half-open interval of journal
-// positions still under consideration.
+// i is the current search bracket — the half-open interval of journal positions
+// still under consideration.
 //
-// On the first call, hasPrev is false and prevPos and prevRec are zero values.
-// On subsequent calls, hasPrev is true and prevPos and prevRec hold the
-// position and record of the most recent probe.
+// pos and rec are the position and record of the most recent probe.
 //
-// If found is true, the record at prevPos/prevRec is the target and next is
-// ignored. When hasPrev is false, found must be false.
+// If found is true, the record at pos is the target and next is ignored.
 //
-// When found is false, next must be within i. When hasPrev is true, next must
-// differ from prevPos; the algorithm's behavior is undefined otherwise.
+// When found is false, next must be within i and must differ from pos. If
+// either condition is violated, AdaptiveSearch returns a [ValueNotFoundError].
 type AdaptiveProbeFunc[T any] func(
 	ctx context.Context,
 	i Interval,
-	prevPos Position,
-	prevRec T,
-	hasPrev bool,
+	pos Position,
+	rec T,
 ) (next Position, found bool, err error)
 
-// AdaptiveSearch searches j within the interval i for a target record, using
-// fn to determine which position to probe at each iteration.
+// AdaptiveSearch searches j within the interval i for a target record, using fn
+// to determine which position to probe at each iteration.
 //
 // Unlike [Search], which always probes the midpoint of the remaining interval,
 // AdaptiveSearch allows the caller to choose the next probe position based on
@@ -78,46 +74,46 @@ type AdaptiveProbeFunc[T any] func(
 // implementing interpolation search and similar algorithms that use record
 // content to estimate where the target is likely to be.
 //
+// probe is the position of the first record to fetch. The caller is expected to
+// compute this using any out-of-band knowledge available, such as a previously
+// fetched record from the same journal.
+//
 // It returns a [ValueNotFoundError] if the target record is not found.
 func AdaptiveSearch[T any](
 	ctx context.Context,
 	j Journal[T],
 	i Interval,
+	probe Position,
 	fn AdaptiveProbeFunc[T],
 ) (Position, T, error) {
 	var zero T
 
-	if i.IsEmpty() {
-		return 0, zero, ValueNotFoundError{}
-	}
-
-	pos, _, err := fn(ctx, i, 0, zero, false)
-	if err != nil {
-		return 0, zero, err
-	}
-
 	for !i.IsEmpty() {
-		rec, err := j.Get(ctx, pos)
+		rec, err := j.Get(ctx, probe)
 		if err != nil {
 			return 0, zero, err
 		}
 
-		next, found, err := fn(ctx, i, pos, rec, true)
+		next, found, err := fn(ctx, i, probe, rec)
 		if err != nil {
 			return 0, zero, err
 		}
 
 		if found {
-			return pos, rec, nil
+			return probe, rec, nil
 		}
 
-		if next > pos {
-			i.Begin = pos + 1
+		if next == probe || !i.Contains(next) {
+			return 0, zero, ValueNotFoundError{}
+		}
+
+		if next > probe {
+			i.Begin = probe + 1
 		} else {
-			i.End = pos
+			i.End = probe
 		}
 
-		pos = next
+		probe = next
 	}
 
 	return 0, zero, ValueNotFoundError{}

--- a/journal/search.go
+++ b/journal/search.go
@@ -88,6 +88,10 @@ func AdaptiveSearch[T any](
 ) (Position, T, error) {
 	var zero T
 
+	if !i.Contains(probe) {
+		return 0, zero, ValueNotFoundError{}
+	}
+
 	for !i.IsEmpty() {
 		rec, err := j.Get(ctx, probe)
 		if err != nil {

--- a/journal/search_test.go
+++ b/journal/search_test.go
@@ -70,24 +70,22 @@ func TestAdaptiveSearch(t *testing.T) {
 	probe := func(
 		_ context.Context,
 		i Interval,
-		prevPos Position,
-		prevRec int,
-		hasPrev bool,
+		pos Position,
+		rec int,
 	) (Position, bool, error) {
-		if hasPrev {
-			if prevRec == datum {
-				return 0, true, nil
-			}
-			if prevRec < datum {
-				i.Begin = prevPos + 1
-			} else {
-				i.End = prevPos
-			}
+		if rec == datum {
+			return 0, true, nil
+		}
+		if rec < datum {
+			i.Begin = pos + 1
+		} else {
+			i.End = pos
 		}
 		return (i.Begin >> 1) + (i.End >> 1), false, nil
 	}
 
-	pos, rec, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, probe)
+	firstPos := (Position(0) >> 1) + (Position(100) >> 1)
+	pos, rec, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, firstPos, probe)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,13 +101,13 @@ func TestAdaptiveSearch(t *testing.T) {
 
 	t.Run("it returns a not found error if the target is not present", func(t *testing.T) {
 		datum = 101
-		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, probe); !IsNotFound(err) {
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, firstPos, probe); !IsNotFound(err) {
 			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
 		}
 	})
 
 	t.Run("it returns a not found error for an empty interval", func(t *testing.T) {
-		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 0}, probe); !IsNotFound(err) {
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 0}, firstPos, probe); !IsNotFound(err) {
 			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
 		}
 	})

--- a/journal/search_test.go
+++ b/journal/search_test.go
@@ -111,6 +111,30 @@ func TestAdaptiveSearch(t *testing.T) {
 			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
 		}
 	})
+
+	t.Run("it returns a not found error if the probe func returns the same position", func(t *testing.T) {
+		fn := func(_ context.Context, _ Interval, pos Position, _ int) (Position, bool, error) {
+			return pos, false, nil
+		}
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, firstPos, fn); !IsNotFound(err) {
+			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
+		}
+	})
+
+	t.Run("it returns a not found error if the probe func returns a position outside the interval", func(t *testing.T) {
+		fn := func(_ context.Context, i Interval, _ Position, _ int) (Position, bool, error) {
+			return i.End + 1, false, nil
+		}
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, firstPos, fn); !IsNotFound(err) {
+			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
+		}
+	})
+
+	t.Run("it returns a not found error if the initial probe position is outside the interval", func(t *testing.T) {
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, Position(100), probe); !IsNotFound(err) {
+			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
+		}
+	})
 }
 
 func TestRangeFromSearchResult(t *testing.T) {

--- a/journal/search_test.go
+++ b/journal/search_test.go
@@ -52,6 +52,69 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+func TestAdaptiveSearch(t *testing.T) {
+	store := &memoryjournal.Store[int]{}
+	j, err := store.Open(t.Context(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.Close()
+
+	for i := range 100 {
+		if err := j.Append(t.Context(), Position(i), i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	datum := 55
+	probe := func(
+		_ context.Context,
+		i Interval,
+		prevPos Position,
+		prevRec int,
+		hasPrev bool,
+	) (Position, bool, error) {
+		if hasPrev {
+			if prevRec == datum {
+				return 0, true, nil
+			}
+			if prevRec < datum {
+				i.Begin = prevPos + 1
+			} else {
+				i.End = prevPos
+			}
+		}
+		return (i.Begin >> 1) + (i.End >> 1), false, nil
+	}
+
+	pos, rec, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := Position(55)
+	if pos != expect {
+		t.Fatalf("unexpected position: got %d, want %d", pos, expect)
+	}
+
+	if rec != datum {
+		t.Fatalf("unexpected record: got %d, want %d", rec, datum)
+	}
+
+	t.Run("it returns a not found error if the target is not present", func(t *testing.T) {
+		datum = 101
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 100}, probe); !IsNotFound(err) {
+			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
+		}
+	})
+
+	t.Run("it returns a not found error for an empty interval", func(t *testing.T) {
+		if _, _, err := AdaptiveSearch(t.Context(), j, Interval{0, 0}, probe); !IsNotFound(err) {
+			t.Fatalf("unexpected error: got %q, want IsNotFound(err) == true", err)
+		}
+	})
+}
+
 func TestRangeFromSearchResult(t *testing.T) {
 	store := &memoryjournal.Store[int]{}
 	j, err := store.Open(t.Context(), "test")


### PR DESCRIPTION
This PR adds `AdaptiveSearch` and `AdaptiveProbeFunc` to the `journal` package.

## AdaptiveSearch

`AdaptiveSearch` searches a journal within an interval for a target record, using a caller-supplied probe function to determine which position to fetch at each iteration.

Unlike `Search`, which always probes the midpoint of the remaining interval, `AdaptiveSearch` lets the caller choose the next probe position based on the content of the most recently fetched record. This makes it suitable for interpolation search and similar algorithms that use record content to estimate where the target is likely to be.

The caller supplies `probe` — the position of the first record to fetch. This allows the caller to apply any out-of-band knowledge (such as a previously fetched record from the same journal) to make an informed first guess.

## AdaptiveProbeFunc

`AdaptiveProbeFunc[T]` is the callback type passed to `AdaptiveSearch`. It receives:
- `ctx` — the context
- `i` — the current search bracket (the half-open interval still under consideration)
- `pos` — the position of the most recently probed record
- `rec` — the value of the most recently probed record

It returns `(next Position, found bool, err error)`. If `found` is true, the record at `pos` is the target. When `found` is false, `next` must be within `i` and must differ from `pos`; otherwise `AdaptiveSearch` returns a `ValueNotFoundError`.