### PR TITLE
feat(s3kv): implement S3-backed key/value store

### DIFF
--- a/driver/aws/internal/s3x/error.go
+++ b/driver/aws/internal/s3x/error.go
@@ -3,27 +3,17 @@ package s3x
 import (
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 )
 
 // IsNotExists returns true if err is an error that indicates the requested
 // object was not found.
 func IsNotExists(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	for err != nil {
-		switch err.(type) {
-		case *types.NotFound:
+	var e smithy.APIError
+	if errors.As(err, &e) {
+		switch e.ErrorCode() {
+		case "NotFound", "NoSuchKey", "NoSuchBucket":
 			return true
-		case *types.NoSuchKey:
-			return true
-		case *types.NoSuchBucket:
-			return true
-		default:
-			err = errors.Unwrap(err)
 		}
 	}
 
@@ -42,18 +32,11 @@ func IgnoreNotExists(err error) error {
 // IsAlreadyExists returns true if err is an error that indicates the requested
 // object already exists.
 func IsAlreadyExists(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	for err != nil {
-		switch err.(type) {
-		case *types.BucketAlreadyExists:
+	var e smithy.APIError
+	if errors.As(err, &e) {
+		switch e.ErrorCode() {
+		case "BucketAlreadyExists", "BucketAlreadyOwnedByYou":
 			return true
-		case *types.BucketAlreadyOwnedByYou:
-			return true
-		default:
-			err = errors.Unwrap(err)
 		}
 	}
 
@@ -62,7 +45,7 @@ func IsAlreadyExists(err error) bool {
 
 // IsConflict returns true if err is an error that indicates an object conflict.
 func IsConflict(err error) bool {
-	var e *smithy.GenericAPIError
+	var e smithy.APIError
 	if errors.As(err, &e) {
 		return e.ErrorCode() == "PreconditionFailed"
 	}

--- a/driver/aws/s3kv/doc.go
+++ b/driver/aws/s3kv/doc.go
@@ -1,0 +1,3 @@
+// Package s3kv provides a [kv.BinaryStore] implementation that persists to an
+// S3 bucket.
+package s3kv

--- a/driver/aws/s3kv/keyspace.go
+++ b/driver/aws/s3kv/keyspace.go
@@ -59,17 +59,17 @@ func (ks *keyspace) Get(ctx context.Context, k []byte) (v []byte, r kv.Revision,
 		return nil, "", err
 	}
 
-	isTomb := isTombstone(res.Metadata)
+	if isTombstone(res.Metadata) {
+		res.Body.Close()
+		return nil, "", nil
+	}
+
 	etag := aws.ToString(res.ETag)
 
 	v, err = io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, "", err
-	}
-
-	if isTomb {
-		return nil, "", nil
 	}
 
 	return v, kv.Revision(etag), nil
@@ -363,17 +363,17 @@ func (ks *keyspace) Range(ctx context.Context, fn kv.BinaryRangeFunc) (err error
 				return err
 			}
 
-			isTomb := isTombstone(res.Metadata)
+			if isTombstone(res.Metadata) {
+				res.Body.Close()
+				continue
+			}
+
 			etag := aws.ToString(res.ETag)
 
 			v, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				return err
-			}
-
-			if isTomb {
-				continue
 			}
 
 			ok, err := fn(ctx, k, v, kv.Revision(etag))

--- a/driver/aws/s3kv/keyspace.go
+++ b/driver/aws/s3kv/keyspace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -13,21 +14,6 @@ import (
 	"github.com/dogmatiq/persistencekit/internal/x/xerrors"
 	"github.com/dogmatiq/persistencekit/kv"
 )
-
-const (
-	// tombstoneTagging is the URL-encoded tag string applied to tombstone objects.
-	// It is used as a lifecycle rule filter to automatically expire tombstones.
-	tombstoneTagging = "type=tombstone"
-
-	// tombstoneMetaKey is the metadata key used to identify tombstone objects
-	// without requiring a separate GetObjectTagging call.
-	tombstoneMetaKey = "tombstone"
-)
-
-// isTombstone returns true if the given object metadata indicates a tombstone.
-func isTombstone(metadata map[string]string) bool {
-	return metadata[tombstoneMetaKey] == "1"
-}
 
 // keyspace is an implementation of [kv.BinaryKeyspace] that persists to an S3
 // bucket.
@@ -122,7 +108,7 @@ func (ks *keyspace) Set(ctx context.Context, k, v []byte, r kv.Revision) (_ kv.R
 	return ks.setWrite(ctx, k, v, r)
 }
 
-// setWrite handles Set when v is non-nil (an insert or update).
+// setWrite handles Set when v is non-empty (an insert or update).
 func (ks *keyspace) setWrite(ctx context.Context, k, v []byte, r kv.Revision) (kv.Revision, error) {
 	key := ks.objectKey(k)
 
@@ -206,7 +192,7 @@ func (ks *keyspace) setWrite(ctx context.Context, k, v []byte, r kv.Revision) (k
 	}
 }
 
-// setDelete handles Set when v is nil (a delete or tombstone write).
+// setDelete handles Set when v is empty (a delete or tombstone write).
 func (ks *keyspace) setDelete(ctx context.Context, k []byte, r kv.Revision) (kv.Revision, error) {
 	key := ks.objectKey(k)
 
@@ -222,8 +208,8 @@ func (ks *keyspace) setDelete(ctx context.Context, k []byte, r kv.Revision) (kv.
 				IfMatch:       aws.String(string(r)),
 				Body:          s3x.NewReadSeeker(nil),
 				ContentLength: aws.Int64(0),
-				Metadata:      map[string]string{tombstoneMetaKey: "1"},
-				Tagging:       aws.String(tombstoneTagging),
+				Metadata:      tombstoneMetadata,
+				Tagging:       tombstoneTagging,
 			},
 		)
 		if s3x.IsConflict(err) || s3x.IsNotExists(err) {
@@ -247,8 +233,8 @@ func (ks *keyspace) setDelete(ctx context.Context, k []byte, r kv.Revision) (kv.
 				IfNoneMatch:   aws.String("*"),
 				Body:          s3x.NewReadSeeker(nil),
 				ContentLength: aws.Int64(0),
-				Metadata:      map[string]string{tombstoneMetaKey: "1"},
-				Tagging:       aws.String(tombstoneTagging),
+				Metadata:      tombstoneMetadata,
+				Tagging:       tombstoneTagging,
 			},
 		)
 		if err == nil {
@@ -307,8 +293,8 @@ func (ks *keyspace) SetUnconditional(ctx context.Context, k, v []byte) (err erro
 				Key:           &key,
 				Body:          s3x.NewReadSeeker(nil),
 				ContentLength: aws.Int64(0),
-				Metadata:      map[string]string{tombstoneMetaKey: "1"},
-				Tagging:       aws.String(tombstoneTagging),
+				Metadata:      tombstoneMetadata,
+				Tagging:       tombstoneTagging,
 			},
 		)
 		if err != nil {
@@ -414,7 +400,12 @@ func (ks *keyspace) objectKey(k []byte) string {
 
 // decodeObjectKey extracts the KV key bytes from a full S3 object key.
 func (ks *keyspace) decodeObjectKey(s3Key string) ([]byte, error) {
-	k, err := hex.DecodeString(s3Key[len(ks.objectKeyPrefix):])
+	suffix, ok := strings.CutPrefix(s3Key, ks.objectKeyPrefix)
+	if !ok {
+		return nil, fmt.Errorf("malformed object key %q: expected prefix %q", s3Key, ks.objectKeyPrefix)
+	}
+
+	k, err := hex.DecodeString(suffix)
 	if err != nil {
 		return nil, fmt.Errorf("malformed object key %q: %w", s3Key, err)
 	}

--- a/driver/aws/s3kv/keyspace.go
+++ b/driver/aws/s3kv/keyspace.go
@@ -1,0 +1,422 @@
+package s3kv
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/awsx"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/s3x"
+	"github.com/dogmatiq/persistencekit/internal/x/xerrors"
+	"github.com/dogmatiq/persistencekit/kv"
+)
+
+const (
+	// tombstoneTagging is the URL-encoded tag string applied to tombstone objects.
+	// It is used as a lifecycle rule filter to automatically expire tombstones.
+	tombstoneTagging = "type=tombstone"
+
+	// tombstoneMetaKey is the metadata key used to identify tombstone objects
+	// without requiring a separate GetObjectTagging call.
+	tombstoneMetaKey = "tombstone"
+)
+
+// isTombstone returns true if the given object metadata indicates a tombstone.
+func isTombstone(metadata map[string]string) bool {
+	return metadata[tombstoneMetaKey] == "1"
+}
+
+// keyspace is an implementation of [kv.BinaryKeyspace] that persists to an S3
+// bucket.
+type keyspace struct {
+	client    *s3.Client
+	onRequest func(any) []func(*s3.Options)
+
+	// name is the keyspace name.
+	name string
+
+	// bucket is the name of the S3 bucket in which the keyspace's key/value
+	// pairs are stored.
+	bucket string
+
+	// objectKeyPrefix is the string prepended to the key of each S3 object. It
+	// includes the keyspace's name, allowing objects for multiple keyspaces to
+	// be stored in the same bucket.
+	objectKeyPrefix string
+}
+
+func (ks *keyspace) Name() string {
+	return ks.name
+}
+
+func (ks *keyspace) Get(ctx context.Context, k []byte) (v []byte, r kv.Revision, err error) {
+	defer xerrors.Wrap(&err, "unable to get pair from the %q keyspace", ks.name)
+
+	key := ks.objectKey(k)
+
+	res, err := awsx.Do(
+		ctx,
+		ks.client.GetObject,
+		ks.onRequest,
+		&s3.GetObjectInput{
+			Bucket: &ks.bucket,
+			Key:    &key,
+		},
+	)
+	if s3x.IsNotExists(err) {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	isTomb := isTombstone(res.Metadata)
+	etag := aws.ToString(res.ETag)
+
+	v, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if isTomb {
+		return nil, "", nil
+	}
+
+	return v, kv.Revision(etag), nil
+}
+
+func (ks *keyspace) Has(ctx context.Context, k []byte) (_ bool, err error) {
+	defer xerrors.Wrap(&err, "unable to check pair in the %q keyspace", ks.name)
+
+	key := ks.objectKey(k)
+
+	res, err := awsx.Do(
+		ctx,
+		ks.client.HeadObject,
+		ks.onRequest,
+		&s3.HeadObjectInput{
+			Bucket: &ks.bucket,
+			Key:    &key,
+		},
+	)
+	if s3x.IsNotExists(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return !isTombstone(res.Metadata), nil
+}
+
+func (ks *keyspace) Set(ctx context.Context, k, v []byte, r kv.Revision) (_ kv.Revision, err error) {
+	defer xerrors.Wrap(&err, "unable to set pair in the %q keyspace", ks.name)
+
+	if len(v) == 0 {
+		return ks.setDelete(ctx, k, r)
+	}
+	return ks.setWrite(ctx, k, v, r)
+}
+
+// setWrite handles Set when v is non-nil (an insert or update).
+func (ks *keyspace) setWrite(ctx context.Context, k, v []byte, r kv.Revision) (kv.Revision, error) {
+	key := ks.objectKey(k)
+
+	if r != "" {
+		// Conditional update: replace only if the current ETag matches r.
+		out, err := awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				IfMatch:       aws.String(string(r)),
+				Body:          s3x.NewReadSeeker(v),
+				ContentLength: aws.Int64(int64(len(v))),
+			},
+		)
+		if s3x.IsConflict(err) || s3x.IsNotExists(err) {
+			return "", kv.ConflictError[[]byte]{Keyspace: ks.name, Key: k, Revision: r}
+		}
+		if err != nil {
+			return "", err
+		}
+		return kv.Revision(aws.ToString(out.ETag)), nil
+	}
+
+	// Insert: the key must not exist or must currently be a tombstone.
+	for {
+		out, err := awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				IfNoneMatch:   aws.String("*"),
+				Body:          s3x.NewReadSeeker(v),
+				ContentLength: aws.Int64(int64(len(v))),
+			},
+		)
+		if err == nil {
+			return kv.Revision(aws.ToString(out.ETag)), nil
+		}
+		if !s3x.IsConflict(err) {
+			return "", err
+		}
+
+		// Something is occupying the slot. Check if it is a tombstone.
+		existingETag, isTomb, err := ks.headObject(ctx, key)
+		if err != nil {
+			return "", err
+		}
+		if existingETag == "" {
+			// Object vanished between PutObject and HeadObject; retry insert.
+			continue
+		}
+		if !isTomb {
+			return "", kv.ConflictError[[]byte]{Keyspace: ks.name, Key: k, Revision: r}
+		}
+
+		// Replace the tombstone with the real value.
+		out, err = awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				IfMatch:       aws.String(existingETag),
+				Body:          s3x.NewReadSeeker(v),
+				ContentLength: aws.Int64(int64(len(v))),
+			},
+		)
+		if err == nil {
+			return kv.Revision(aws.ToString(out.ETag)), nil
+		}
+		if !s3x.IsConflict(err) {
+			return "", err
+		}
+		// Tombstone was replaced concurrently; retry from the top.
+	}
+}
+
+// setDelete handles Set when v is nil (a delete or tombstone write).
+func (ks *keyspace) setDelete(ctx context.Context, k []byte, r kv.Revision) (kv.Revision, error) {
+	key := ks.objectKey(k)
+
+	if r != "" {
+		// Conditional delete: write tombstone only if the current ETag matches r.
+		_, err := awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				IfMatch:       aws.String(string(r)),
+				Body:          s3x.NewReadSeeker(nil),
+				ContentLength: aws.Int64(0),
+				Metadata:      map[string]string{tombstoneMetaKey: "1"},
+				Tagging:       aws.String(tombstoneTagging),
+			},
+		)
+		if s3x.IsConflict(err) || s3x.IsNotExists(err) {
+			return "", kv.ConflictError[[]byte]{Keyspace: ks.name, Key: k, Revision: r}
+		}
+		if err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+
+	// Delete with no revision: the key must not exist (or already be a tombstone).
+	for {
+		_, err := awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				IfNoneMatch:   aws.String("*"),
+				Body:          s3x.NewReadSeeker(nil),
+				ContentLength: aws.Int64(0),
+				Metadata:      map[string]string{tombstoneMetaKey: "1"},
+				Tagging:       aws.String(tombstoneTagging),
+			},
+		)
+		if err == nil {
+			return "", nil
+		}
+		if !s3x.IsConflict(err) {
+			return "", err
+		}
+
+		// Something is occupying the slot. Check what it is.
+		existingETag, isTomb, err := ks.headObject(ctx, key)
+		if err != nil {
+			return "", err
+		}
+		if existingETag == "" || isTomb {
+			// Key is absent or already a tombstone — intent satisfied.
+			return "", nil
+		}
+		return "", kv.ConflictError[[]byte]{Keyspace: ks.name, Key: k, Revision: r}
+	}
+}
+
+// headObject returns the ETag and tombstone status of the object at key.
+// If the object does not exist, etag is "" and isTomb is false.
+func (ks *keyspace) headObject(ctx context.Context, key string) (etag string, isTomb bool, err error) {
+	res, err := awsx.Do(
+		ctx,
+		ks.client.HeadObject,
+		ks.onRequest,
+		&s3.HeadObjectInput{
+			Bucket: &ks.bucket,
+			Key:    &key,
+		},
+	)
+	if s3x.IsNotExists(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return aws.ToString(res.ETag), isTombstone(res.Metadata), nil
+}
+
+func (ks *keyspace) SetUnconditional(ctx context.Context, k, v []byte) (err error) {
+	defer xerrors.Wrap(&err, "unable to set pair unconditionally in the %q keyspace", ks.name)
+
+	key := ks.objectKey(k)
+
+	if len(v) == 0 {
+		_, err := awsx.Do(
+			ctx,
+			ks.client.PutObject,
+			ks.onRequest,
+			&s3.PutObjectInput{
+				Bucket:        &ks.bucket,
+				Key:           &key,
+				Body:          s3x.NewReadSeeker(nil),
+				ContentLength: aws.Int64(0),
+				Metadata:      map[string]string{tombstoneMetaKey: "1"},
+				Tagging:       aws.String(tombstoneTagging),
+			},
+		)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err = awsx.Do(
+		ctx,
+		ks.client.PutObject,
+		ks.onRequest,
+		&s3.PutObjectInput{
+			Bucket:        &ks.bucket,
+			Key:           &key,
+			Body:          s3x.NewReadSeeker(v),
+			ContentLength: aws.Int64(int64(len(v))),
+		},
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ks *keyspace) Range(ctx context.Context, fn kv.BinaryRangeFunc) (err error) {
+	defer xerrors.Wrap(&err, "unable to range over the %q keyspace", ks.name)
+
+	req := &s3.ListObjectsV2Input{
+		Bucket: &ks.bucket,
+		Prefix: aws.String(ks.objectKeyPrefix),
+	}
+
+	for {
+		list, err := awsx.Do(
+			ctx,
+			ks.client.ListObjectsV2,
+			ks.onRequest,
+			req,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, obj := range list.Contents {
+			s3Key := aws.ToString(obj.Key)
+
+			k, err := ks.decodeObjectKey(s3Key)
+			if err != nil {
+				return err
+			}
+
+			res, err := awsx.Do(
+				ctx,
+				ks.client.GetObject,
+				ks.onRequest,
+				&s3.GetObjectInput{
+					Bucket: &ks.bucket,
+					Key:    &s3Key,
+				},
+			)
+			if s3x.IsNotExists(err) {
+				continue // Deleted between list and get.
+			}
+			if err != nil {
+				return err
+			}
+
+			isTomb := isTombstone(res.Metadata)
+			etag := aws.ToString(res.ETag)
+
+			v, err := io.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				return err
+			}
+
+			if isTomb {
+				continue
+			}
+
+			ok, err := fn(ctx, k, v, kv.Revision(etag))
+			if !ok || err != nil {
+				return err
+			}
+		}
+
+		if list.IsTruncated == nil || !*list.IsTruncated {
+			return nil
+		}
+		req.ContinuationToken = list.NextContinuationToken
+	}
+}
+
+func (ks *keyspace) Close() error {
+	return nil
+}
+
+// objectKey returns the S3 object key for the given KV key.
+func (ks *keyspace) objectKey(k []byte) string {
+	return ks.objectKeyPrefix + hex.EncodeToString(k)
+}
+
+// decodeObjectKey extracts the KV key bytes from a full S3 object key.
+func (ks *keyspace) decodeObjectKey(s3Key string) ([]byte, error) {
+	k, err := hex.DecodeString(s3Key[len(ks.objectKeyPrefix):])
+	if err != nil {
+		return nil, fmt.Errorf("malformed object key %q: %w", s3Key, err)
+	}
+	return k, nil
+}

--- a/driver/aws/s3kv/keyspace.go
+++ b/driver/aws/s3kv/keyspace.go
@@ -185,10 +185,10 @@ func (ks *keyspace) setWrite(ctx context.Context, k, v []byte, r kv.Revision) (k
 		if err == nil {
 			return kv.Revision(aws.ToString(out.ETag)), nil
 		}
-		if !s3x.IsConflict(err) {
+		if !s3x.IsConflict(err) && !s3x.IsNotExists(err) {
 			return "", err
 		}
-		// Tombstone was replaced concurrently; retry from the top.
+		// Tombstone was replaced or removed concurrently; retry from the top.
 	}
 }
 

--- a/driver/aws/s3kv/store.go
+++ b/driver/aws/s3kv/store.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/awsx"
 	"github.com/dogmatiq/persistencekit/driver/aws/internal/s3x"
 	"github.com/dogmatiq/persistencekit/kv"
 )
@@ -90,30 +87,5 @@ func (s *store) createBucket(ctx context.Context) error {
 		return err
 	}
 
-	_, err := awsx.Do(
-		ctx,
-		s.Client.PutBucketLifecycleConfiguration,
-		s.OnRequest,
-		&s3.PutBucketLifecycleConfigurationInput{
-			Bucket: aws.String(s.Bucket),
-			LifecycleConfiguration: &types.BucketLifecycleConfiguration{
-				Rules: []types.LifecycleRule{
-					{
-						ID:     aws.String("expire-tombstones"),
-						Status: types.ExpirationStatusEnabled,
-						Filter: &types.LifecycleRuleFilter{
-							Tag: &types.Tag{
-								Key:   aws.String("type"),
-								Value: aws.String("tombstone"),
-							},
-						},
-						Expiration: &types.LifecycleExpiration{
-							Days: aws.Int32(1),
-						},
-					},
-				},
-			},
-		},
-	)
-	return err
+	return ensureTombstoneLifecycleRule(ctx, s)
 }

--- a/driver/aws/s3kv/store.go
+++ b/driver/aws/s3kv/store.go
@@ -1,0 +1,119 @@
+package s3kv
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/dogmatiq/enginekit/x/xsync"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/awsx"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/s3x"
+	"github.com/dogmatiq/persistencekit/kv"
+)
+
+// store is an implementation of [kv.BinaryStore] that persists to an S3 bucket.
+type store struct {
+	Client    *s3.Client
+	Bucket    string
+	OnRequest func(any) []func(*s3.Options)
+
+	createBucketOnce xsync.SucceedOnce
+}
+
+// NewBinaryStore returns a new [kv.BinaryStore] that uses the given S3 client
+// to store key/value pairs in the given bucket.
+func NewBinaryStore(
+	client *s3.Client,
+	bucket string,
+	options ...Option,
+) kv.BinaryStore {
+	if bucket == "" {
+		panic("bucket name must not be empty")
+	}
+
+	s := &store{
+		Client: client,
+		Bucket: bucket,
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
+	return s
+}
+
+// Option is a functional option that changes the behavior of [NewBinaryStore].
+type Option func(*store)
+
+// WithRequestHook is an [Option] that configures fn as a pre-request hook.
+//
+// Before each S3 API request, fn is passed a pointer to the input struct, e.g.
+// [s3.GetObjectInput], which it may modify in-place. It may be called with any
+// S3 request type. The types of requests used may change in any version without
+// notice.
+//
+// Any functions returned by fn will be applied to the request's options before
+// the request is sent.
+func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
+	return func(s *store) {
+		s.OnRequest = fn
+	}
+}
+
+// Open returns the keyspace with the given name.
+func (s *store) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
+	if err := s.createBucketOnce.Do(ctx, s.createBucket); err != nil {
+		return nil, err
+	}
+
+	ks := &keyspace{
+		client:          s.Client,
+		onRequest:       s.OnRequest,
+		name:            name,
+		bucket:          s.Bucket,
+		objectKeyPrefix: "kv/" + url.PathEscape(name) + "/",
+	}
+
+	return ks, nil
+}
+
+func (s *store) createBucket(ctx context.Context) error {
+	if err := s3x.CreateBucketIfNotExists(
+		ctx,
+		s.Client,
+		s.Bucket,
+		s.OnRequest,
+	); err != nil {
+		return err
+	}
+
+	_, err := awsx.Do(
+		ctx,
+		s.Client.PutBucketLifecycleConfiguration,
+		s.OnRequest,
+		&s3.PutBucketLifecycleConfigurationInput{
+			Bucket: aws.String(s.Bucket),
+			LifecycleConfiguration: &types.BucketLifecycleConfiguration{
+				Rules: []types.LifecycleRule{
+					{
+						ID:     aws.String("expire-tombstones"),
+						Status: types.ExpirationStatusEnabled,
+						Filter: &types.LifecycleRuleFilter{
+							Tag: &types.Tag{
+								Key:   aws.String("type"),
+								Value: aws.String("tombstone"),
+							},
+						},
+						Expiration: &types.LifecycleExpiration{
+							Days: aws.Int32(1),
+						},
+					},
+				},
+			},
+		},
+	)
+	return err
+}

--- a/driver/aws/s3kv/store_test.go
+++ b/driver/aws/s3kv/store_test.go
@@ -1,0 +1,46 @@
+package s3kv
+package s3kv_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/s3x"
+	. "github.com/dogmatiq/persistencekit/driver/aws/s3kv"
+	"github.com/dogmatiq/persistencekit/internal/x/xtesting"
+	"github.com/dogmatiq/persistencekit/kv"
+)
+
+func TestStore(t *testing.T) {
+	client, bucket := setup(t)
+	kv.RunTests(
+		t,
+		NewBinaryStore(client, bucket),
+	)
+}
+
+func BenchmarkStore(b *testing.B) {
+	client, bucket := setup(b)
+	kv.RunBenchmarks(
+		b,
+		NewBinaryStore(client, bucket),
+	)
+}
+
+func setup(t testing.TB) (*s3.Client, string) {
+	client := s3x.NewTestClient(t)
+	bucket := xtesting.UniqueName("bucket")
+
+	t.Cleanup(func() {
+		if err := s3x.DeleteBucketIfExists(
+			xtesting.ContextForCleanup(t),
+			client,
+			bucket,
+			nil,
+		); err != nil {
+			t.Error(err)
+		}
+	})
+
+	return client, bucket
+}

--- a/driver/aws/s3kv/store_test.go
+++ b/driver/aws/s3kv/store_test.go
@@ -1,4 +1,3 @@
-package s3kv
 package s3kv_test
 
 import (

--- a/driver/aws/s3kv/tombstone.go
+++ b/driver/aws/s3kv/tombstone.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	// tombstoneTagging is the URL-encoded tag string applied to tombstone objects.
-	tombstoneTagging = aws.String(url.QueryEscape(tombstoneTagKey) + "=" + tombstoneTagValue)
+	tombstoneTagging = aws.String(url.Values{tombstoneTagKey: []string{tombstoneTagValue}}.Encode())
 
 	// tombstoneMetadata is the S3 object metadata applied to tombstone objects.
 	tombstoneMetadata = map[string]string{tombstoneMetaKey: tombstoneMetaValue}

--- a/driver/aws/s3kv/tombstone.go
+++ b/driver/aws/s3kv/tombstone.go
@@ -1,0 +1,103 @@
+package s3kv
+
+import (
+	"context"
+	"errors"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/awsx"
+)
+
+const (
+	// tombstoneLifecycleRuleID is the ID of the S3 lifecycle rule that
+	// automatically expires tombstone objects.
+	tombstoneLifecycleRuleID = "dogmatiq.io/persistencekit/tombstone"
+
+	// tombstoneTagKey and tombstoneTagValue are the S3 object tag applied to
+	// tombstone objects. S3 lifecycle rules can only filter by tag (not
+	// metadata), so tags are required to target the auto-expiry rule.
+	tombstoneTagKey   = "dogmatiq.io/persistencekit/tombstone"
+	tombstoneTagValue = "true"
+
+	// tombstoneMetaKey and tombstoneMetaValue are the S3 object metadata key
+	// and value used to detect tombstones inline. GetObject and HeadObject
+	// return metadata in the response body, but not tags -- tags require a
+	// separate GetObjectTagging call. The metadata avoids that extra round-trip
+	// on every read.
+	tombstoneMetaKey   = "tombstone"
+	tombstoneMetaValue = "true"
+)
+
+var (
+	// tombstoneTagging is the URL-encoded tag string applied to tombstone objects.
+	tombstoneTagging = aws.String(url.QueryEscape(tombstoneTagKey) + "=" + tombstoneTagValue)
+
+	// tombstoneMetadata is the S3 object metadata applied to tombstone objects.
+	tombstoneMetadata = map[string]string{tombstoneMetaKey: tombstoneMetaValue}
+)
+
+// isTombstone returns true if the given object metadata indicates a tombstone.
+func isTombstone(metadata map[string]string) bool {
+	return metadata[tombstoneMetaKey] == tombstoneMetaValue
+}
+
+// ensureTombstoneLifecycleRule adds an S3 lifecycle rule to expire tombstone
+// objects if one is not already present. It reads the existing rules before
+// writing to avoid clobbering any user-managed rules.
+func ensureTombstoneLifecycleRule(ctx context.Context, s *store) error {
+	res, err := awsx.Do(
+		ctx,
+		s.Client.GetBucketLifecycleConfiguration,
+		s.OnRequest,
+		&s3.GetBucketLifecycleConfigurationInput{
+			Bucket: aws.String(s.Bucket),
+		},
+	)
+
+	var rules []types.LifecycleRule
+	if err != nil {
+		var apiErr smithy.APIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "NoSuchLifecycleConfiguration" {
+			return err
+		}
+	} else {
+		for _, r := range res.Rules {
+			if aws.ToString(r.ID) == tombstoneLifecycleRuleID {
+				return nil // Rule already present.
+			}
+		}
+		rules = res.Rules
+	}
+
+	rules = append(rules, types.LifecycleRule{
+		ID:     aws.String(tombstoneLifecycleRuleID),
+		Status: types.ExpirationStatusEnabled,
+		Filter: &types.LifecycleRuleFilter{
+			Tag: &types.Tag{
+				Key:   aws.String(tombstoneTagKey),
+				Value: aws.String(tombstoneTagValue),
+			},
+		},
+		Expiration: &types.LifecycleExpiration{
+			Days: aws.Int32(1),
+		},
+	})
+
+	_, err = awsx.Do(
+		ctx,
+		s.Client.PutBucketLifecycleConfiguration,
+		s.OnRequest,
+		&s3.PutBucketLifecycleConfigurationInput{
+			Bucket: aws.String(s.Bucket),
+			LifecycleConfiguration: &types.BucketLifecycleConfiguration{
+				Rules: rules,
+			},
+		},
+	)
+
+	return err
+}

--- a/internal/x/xerrors/error.go
+++ b/internal/x/xerrors/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dogmatiq/persistencekit/journal"
+	"github.com/dogmatiq/persistencekit/kv"
 )
 
 // Wrap adds additional context to an error.
@@ -21,6 +22,10 @@ func Wrap(err *error, format string, args ...any) {
 	}
 
 	if journal.IsConflict(*err) {
+		return
+	}
+
+	if kv.IsConflict(*err) {
 		return
 	}
 

--- a/kv/test.go
+++ b/kv/test.go
@@ -280,6 +280,77 @@ func RunTests(
 						t.Fatal(err)
 					}
 				})
+
+				t.Run("it allows insertion after deletion", func(t *testing.T) {
+					t.Parallel()
+
+					ks := setup(t)
+
+					k := []byte("<key>")
+
+					r, err := ks.Set(t.Context(), k, []byte("<value-1>"), "")
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := ks.Set(t.Context(), k, nil, r); err != nil {
+						t.Fatal(err)
+					}
+
+					r2, err := ks.Set(t.Context(), k, []byte("<value-2>"), "")
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if r2 == "" {
+						t.Fatal("expected non-empty revision after re-insertion")
+					}
+
+					v, got, err := ks.Get(t.Context(), k)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if !bytes.Equal(v, []byte("<value-2>")) {
+						t.Fatalf("unexpected value: got %q, want %q", v, "<value-2>")
+					}
+
+					if got != r2 {
+						t.Fatalf("unexpected revision: got %q, want %q", got, r2)
+					}
+				})
+
+				t.Run("it returns a ConflictError if the key has been deleted and a non-empty revision is given", func(t *testing.T) {
+					t.Parallel()
+
+					ks := setup(t)
+
+					k := []byte("<key>")
+
+					r, err := ks.Set(t.Context(), k, []byte("<value>"), "")
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := ks.Set(t.Context(), k, nil, r); err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = ks.Set(t.Context(), k, []byte("<value>"), "<wrong>")
+
+					expect := ConflictError[[]byte]{
+						Keyspace: ks.Name(),
+						Key:      k,
+						Revision: "<wrong>",
+					}
+					if !reflect.DeepEqual(err, expect) {
+						t.Fatalf("unexpected error: got %q, want %q", err, expect)
+					}
+
+					if !IsConflict(err) {
+						t.Fatalf("expected IsConflict to return true")
+					}
+				})
 			})
 
 			t.Run("it does not keep a reference to the key slice", func(t *testing.T) {
@@ -488,6 +559,47 @@ func RunTests(
 
 		t.Run("Range", func(t *testing.T) {
 			t.Parallel()
+
+			t.Run("it does not visit deleted keys", func(t *testing.T) {
+				t.Parallel()
+
+				ks := setup(t)
+
+				for n := range 5 {
+					k := []byte(fmt.Sprintf("<key-%d>", n))
+					v := []byte(fmt.Sprintf("<value-%d>", n))
+
+					r, err := ks.Set(t.Context(), k, v, "")
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if n%2 != 0 {
+						if _, err := ks.Set(t.Context(), k, nil, r); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
+				var visited []string
+
+				if err := ks.Range(
+					t.Context(),
+					func(_ context.Context, k, _ []byte, _ Revision) (bool, error) {
+						visited = append(visited, string(k))
+						return true, nil
+					},
+				); err != nil {
+					t.Fatal(err)
+				}
+
+				expect := []string{"<key-0>", "<key-2>", "<key-4>"}
+				slices.Sort(visited)
+
+				if diff := cmp.Diff(expect, visited); diff != "" {
+					t.Fatalf("unexpected keys visited (-want +got):\n%s", diff)
+				}
+			})
 
 			t.Run("calls the function for each key in the keyspace", func(t *testing.T) {
 				t.Parallel()


### PR DESCRIPTION
Implements a key/value store backed by S3, mirroring the existing `s3journal` driver.

## Changes

### `driver/aws/s3kv`
- New `BinaryStore` and `BinaryKeyspace` implementation backed by S3
- Keys are stored as hex-encoded S3 object keys under a per-keyspace prefix
- Deletions are represented as tombstone objects (empty body, `tombstone=true` metadata, `dogmatiq.io/persistencekit/tombstone=true` tag) rather than actual S3 deletes, to avoid issues with S3's eventual consistency model for object listings
- A bucket lifecycle rule automatically expires tombstones after 1 day; the rule is added lazily on first use, reading existing rules before writing to avoid clobbering user-managed rules
- Conditional writes use `IfMatch` (ETag) and `IfNoneMatch: "*"` for optimistic concurrency

### `driver/aws/internal/s3x`
- Simplified `IsNotExists`, `IsAlreadyExists`, and `IsConflict` to check against the `smithy.APIError` interface rather than walking the error chain with type switches — this also fixes a gap where `PutObject` 404s were returned as `smithy.GenericAPIError` (not a typed shape) and were not previously detected

### `internal/x/xerrors`
- Added `kv.IsConflict` guard to `Wrap`, consistent with the existing `journal.IsConflict` guard