### PR TITLE
Add Provision() method to store interfaces and implementations

### DIFF
--- a/driver/aws/dynamojournal/doc.go
+++ b/driver/aws/dynamojournal/doc.go
@@ -1,3 +1,18 @@
-// Package dynamojournal provides an implementation of [journal.BinaryStore] that
-// persists to a DynamoDB table.
+// Package dynamojournal provides an implementation of [journal.BinaryStore]
+// that persists to a DynamoDB table.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the DynamoDB table:
+//   - dynamodb:DescribeTable
+//   - dynamodb:GetItem
+//   - dynamodb:PutItem
+//   - dynamodb:UpdateItem
+//   - dynamodb:Query
+//
+// If the table does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - dynamodb:CreateTable
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package dynamojournal

--- a/driver/aws/dynamojournal/doc.go
+++ b/driver/aws/dynamojournal/doc.go
@@ -14,5 +14,6 @@
 // automatically, which requires the following additional action:
 //   - dynamodb:CreateTable
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package dynamojournal

--- a/driver/aws/dynamojournal/schema.go
+++ b/driver/aws/dynamojournal/schema.go
@@ -1,6 +1,8 @@
 package dynamojournal
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -51,6 +53,35 @@ var (
 		Value: marshalPositionBefore(0),
 	}
 )
+
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *store) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.Client,
+			s.Table,
+			s.OnRequest,
+			dynamox.KeyAttr{
+				Name:    &journalAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &positionAttr,
+				Type:    types.ScalarAttributeTypeN,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
 
 // prepareRequests prepares the DynamoDB API requests used by the journal.
 //

--- a/driver/aws/dynamojournal/schema.go
+++ b/driver/aws/dynamojournal/schema.go
@@ -1,8 +1,6 @@
 package dynamojournal
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -53,26 +51,6 @@ var (
 		Value: marshalPositionBefore(0),
 	}
 )
-
-// createTable creates the DynamoDB table if it does not already exist.
-func (s *store) createTable(ctx context.Context) error {
-	return dynamox.CreateTableIfNotExists(
-		ctx,
-		s.Client,
-		s.Table,
-		s.OnRequest,
-		dynamox.KeyAttr{
-			Name:    &journalAttr,
-			Type:    types.ScalarAttributeTypeS,
-			KeyType: types.KeyTypeHash,
-		},
-		dynamox.KeyAttr{
-			Name:    &positionAttr,
-			Type:    types.ScalarAttributeTypeN,
-			KeyType: types.KeyTypeRange,
-		},
-	)
-}
 
 // prepareRequests prepares the DynamoDB API requests used by the journal.
 //

--- a/driver/aws/dynamojournal/store.go
+++ b/driver/aws/dynamojournal/store.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/journal"
 )
 
@@ -59,35 +57,6 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 	return func(s *store) {
 		s.OnRequest = fn
 	}
-}
-
-// Provision creates the DynamoDB table used by the store if it does not already
-// exist.
-//
-// The store also creates the table on first use if it does not exist. Provision
-// allows infrastructure to be created ahead of time, for example as part of a
-// deployment pipeline, so that the application itself does not need broad IAM
-// permissions.
-func (s *store) Provision(ctx context.Context) error {
-	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		_, err := dynamox.CreateTableIfNotExists(
-			ctx,
-			s.Client,
-			s.Table,
-			s.OnRequest,
-			dynamox.KeyAttr{
-				Name:    &journalAttr,
-				Type:    types.ScalarAttributeTypeS,
-				KeyType: types.KeyTypeHash,
-			},
-			dynamox.KeyAttr{
-				Name:    &positionAttr,
-				Type:    types.ScalarAttributeTypeN,
-				KeyType: types.KeyTypeRange,
-			},
-		)
-		return err
-	})
 }
 
 // Open returns the journal with the given name.

--- a/driver/aws/dynamojournal/store.go
+++ b/driver/aws/dynamojournal/store.go
@@ -10,12 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/journal"
 )
 
-// BinaryStore is an implementation of [journal.BinaryStore] that persists to a
+// store is an implementation of [journal.BinaryStore] that persists to a
 // DynamoDB table.
-type BinaryStore struct {
-	client        *dynamodb.Client
-	table         string
-	onRequest     func(any) []func(*dynamodb.Options)
+type store struct {
+	Client    *dynamodb.Client
+	Table     string
+	OnRequest func(any) []func(*dynamodb.Options)
+
 	provisionOnce xsync.SucceedOnce
 }
 
@@ -25,10 +26,14 @@ func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) *BinaryStore {
-	s := &BinaryStore{
-		client: client,
-		table:  table,
+) journal.BinaryStore {
+	if table == "" {
+		panic("table name must not be empty")
+	}
+
+	s := &store{
+		Client: client,
+		Table:  table,
 	}
 
 	for _, opt := range options {
@@ -39,7 +44,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -51,8 +56,8 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
@@ -63,13 +68,13 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 // allows infrastructure to be created ahead of time, for example as part of a
 // deployment pipeline, so that the application itself does not need broad IAM
 // permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
 		_, err := dynamox.CreateTableIfNotExists(
 			ctx,
-			s.client,
-			s.table,
-			s.onRequest,
+			s.Client,
+			s.Table,
+			s.OnRequest,
 			dynamox.KeyAttr{
 				Name:    &journalAttr,
 				Type:    types.ScalarAttributeTypeS,
@@ -86,17 +91,17 @@ func (s *BinaryStore) Provision(ctx context.Context) error {
 }
 
 // Open returns the journal with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
+func (s *store) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	j := &journ{
-		Client:    s.client,
-		OnRequest: s.onRequest,
+		Client:    s.Client,
+		OnRequest: s.OnRequest,
 	}
 
-	if err := j.init(ctx, s.table, name); err != nil {
+	if err := j.init(ctx, s.Table, name); err != nil {
 		return nil, err
 	}
 

--- a/driver/aws/dynamojournal/store.go
+++ b/driver/aws/dynamojournal/store.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/journal"
 )
 
-// store is an implementation of [journal.BinaryStore] that persists to a
+// BinaryStore is an implementation of [journal.BinaryStore] that persists to a
 // DynamoDB table.
-type store struct {
-	Client    *dynamodb.Client
-	Table     string
-	OnRequest func(any) []func(*dynamodb.Options)
-
-	createTableOnce xsync.SucceedOnce
+type BinaryStore struct {
+	client        *dynamodb.Client
+	table         string
+	onRequest     func(any) []func(*dynamodb.Options)
+	provisionOnce xsync.SucceedOnce
 }
 
 // NewBinaryStore returns a new [journal.BinaryStore] that uses the given
@@ -24,10 +25,10 @@ func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) journal.BinaryStore {
-	s := &store{
-		Client: client,
-		Table:  table,
+) *BinaryStore {
+	s := &BinaryStore{
+		client: client,
+		table:  table,
 	}
 
 	for _, opt := range options {
@@ -38,7 +39,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -50,23 +51,52 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.client,
+			s.table,
+			s.onRequest,
+			dynamox.KeyAttr{
+				Name:    &journalAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &positionAttr,
+				Type:    types.ScalarAttributeTypeN,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
+
 // Open returns the journal with the given name.
-func (s *store) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
-	if err := s.createTableOnce.Do(ctx, s.createTable); err != nil {
+func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	j := &journ{
-		Client:    s.Client,
-		OnRequest: s.OnRequest,
+		Client:    s.client,
+		OnRequest: s.onRequest,
 	}
 
-	if err := j.init(ctx, s.Table, name); err != nil {
+	if err := j.init(ctx, s.table, name); err != nil {
 		return nil, err
 	}
 

--- a/driver/aws/dynamokv/doc.go
+++ b/driver/aws/dynamokv/doc.go
@@ -14,5 +14,6 @@
 // automatically, which requires the following additional action:
 //   - dynamodb:CreateTable
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package dynamokv

--- a/driver/aws/dynamokv/doc.go
+++ b/driver/aws/dynamokv/doc.go
@@ -1,3 +1,18 @@
 // Package dynamokv provides a [kv.BinaryStore] implementation that persists to
 // a DynamoDB table.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the DynamoDB table:
+//   - dynamodb:DescribeTable
+//   - dynamodb:GetItem
+//   - dynamodb:UpdateItem
+//   - dynamodb:DeleteItem
+//   - dynamodb:Query
+//
+// If the table does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - dynamodb:CreateTable
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package dynamokv

--- a/driver/aws/dynamokv/schema.go
+++ b/driver/aws/dynamokv/schema.go
@@ -1,9 +1,12 @@
 package dynamokv
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 )
 
 var (
@@ -29,6 +32,35 @@ var (
 	// unnecessary data.
 	nonExistentAttr = "X"
 )
+
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *store) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.Client,
+			s.Table,
+			s.OnRequest,
+			dynamox.KeyAttr{
+				Name:    &keyspaceAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &keyAttr,
+				Type:    types.ScalarAttributeTypeB,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
 
 func (ks *keyspace) prepareRequests(table string) {
 	key := map[string]types.AttributeValue{

--- a/driver/aws/dynamokv/schema.go
+++ b/driver/aws/dynamokv/schema.go
@@ -1,12 +1,9 @@
 package dynamokv
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 )
 
 var (
@@ -32,26 +29,6 @@ var (
 	// unnecessary data.
 	nonExistentAttr = "X"
 )
-
-// createTable creates the DynamoDB table if it does not already exist.
-func (s *store) createTable(ctx context.Context) error {
-	return dynamox.CreateTableIfNotExists(
-		ctx,
-		s.Client,
-		s.Table,
-		s.OnRequest,
-		dynamox.KeyAttr{
-			Name:    &keyspaceAttr,
-			Type:    types.ScalarAttributeTypeS,
-			KeyType: types.KeyTypeHash,
-		},
-		dynamox.KeyAttr{
-			Name:    &keyAttr,
-			Type:    types.ScalarAttributeTypeB,
-			KeyType: types.KeyTypeRange,
-		},
-	)
-}
 
 func (ks *keyspace) prepareRequests(table string) {
 	key := map[string]types.AttributeValue{

--- a/driver/aws/dynamokv/store.go
+++ b/driver/aws/dynamokv/store.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/kv"
 )
 
@@ -59,35 +57,6 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 	return func(s *store) {
 		s.OnRequest = fn
 	}
-}
-
-// Provision creates the DynamoDB table used by the store if it does not already
-// exist.
-//
-// The store also creates the table on first use if it does not exist. Provision
-// allows infrastructure to be created ahead of time, for example as part of a
-// deployment pipeline, so that the application itself does not need broad IAM
-// permissions.
-func (s *store) Provision(ctx context.Context) error {
-	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		_, err := dynamox.CreateTableIfNotExists(
-			ctx,
-			s.Client,
-			s.Table,
-			s.OnRequest,
-			dynamox.KeyAttr{
-				Name:    &keyspaceAttr,
-				Type:    types.ScalarAttributeTypeS,
-				KeyType: types.KeyTypeHash,
-			},
-			dynamox.KeyAttr{
-				Name:    &keyAttr,
-				Type:    types.ScalarAttributeTypeB,
-				KeyType: types.KeyTypeRange,
-			},
-		)
-		return err
-	})
 }
 
 // Open returns the keyspace with the given name.

--- a/driver/aws/dynamokv/store.go
+++ b/driver/aws/dynamokv/store.go
@@ -4,18 +4,19 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/kv"
 )
 
-// BinaryStore is an implementation of [kv.BinaryStore] that persists to a
-// DynamoDB table.
-type store struct {
-	Client    *dynamodb.Client
-	Table     string
-	OnRequest func(any) []func(*dynamodb.Options)
-
-	createTableOnce xsync.SucceedOnce
+// BinaryStore is an implementation of [kv.BinaryStore] that persists to a DynamoDB
+// table.
+type BinaryStore struct {
+	client        *dynamodb.Client
+	table         string
+	onRequest     func(any) []func(*dynamodb.Options)
+	provisionOnce xsync.SucceedOnce
 }
 
 // NewBinaryStore returns a new [kv.BinaryStore] that uses the given DynamoDB
@@ -24,14 +25,14 @@ func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) kv.BinaryStore {
+) *BinaryStore {
 	if table == "" {
 		panic("table name must not be empty")
 	}
 
-	s := &store{
-		Client: client,
-		Table:  table,
+	s := &BinaryStore{
+		client: client,
+		table:  table,
 	}
 
 	for _, opt := range options {
@@ -42,7 +43,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -54,24 +55,53 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.client,
+			s.table,
+			s.onRequest,
+			dynamox.KeyAttr{
+				Name:    &keyspaceAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &keyAttr,
+				Type:    types.ScalarAttributeTypeB,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
+
 // Open returns the keyspace with the given name.
-func (s *store) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
-	if err := s.createTableOnce.Do(ctx, s.createTable); err != nil {
+func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	ks := &keyspace{
-		Client:    s.Client,
-		OnRequest: s.OnRequest,
+		Client:    s.client,
+		OnRequest: s.onRequest,
 	}
 
 	ks.attr.Keyspace.Value = name
-	ks.prepareRequests(s.Table)
+	ks.prepareRequests(s.table)
 
 	return ks, nil
 }

--- a/driver/aws/dynamokv/store.go
+++ b/driver/aws/dynamokv/store.go
@@ -10,12 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/kv"
 )
 
-// BinaryStore is an implementation of [kv.BinaryStore] that persists to a DynamoDB
+// store is an implementation of [kv.BinaryStore] that persists to a DynamoDB
 // table.
-type BinaryStore struct {
-	client        *dynamodb.Client
-	table         string
-	onRequest     func(any) []func(*dynamodb.Options)
+type store struct {
+	Client    *dynamodb.Client
+	Table     string
+	OnRequest func(any) []func(*dynamodb.Options)
+
 	provisionOnce xsync.SucceedOnce
 }
 
@@ -25,14 +26,14 @@ func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) *BinaryStore {
+) kv.BinaryStore {
 	if table == "" {
 		panic("table name must not be empty")
 	}
 
-	s := &BinaryStore{
-		client: client,
-		table:  table,
+	s := &store{
+		Client: client,
+		Table:  table,
 	}
 
 	for _, opt := range options {
@@ -43,7 +44,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -55,8 +56,8 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
@@ -67,13 +68,13 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 // allows infrastructure to be created ahead of time, for example as part of a
 // deployment pipeline, so that the application itself does not need broad IAM
 // permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
 		_, err := dynamox.CreateTableIfNotExists(
 			ctx,
-			s.client,
-			s.table,
-			s.onRequest,
+			s.Client,
+			s.Table,
+			s.OnRequest,
 			dynamox.KeyAttr{
 				Name:    &keyspaceAttr,
 				Type:    types.ScalarAttributeTypeS,
@@ -90,18 +91,18 @@ func (s *BinaryStore) Provision(ctx context.Context) error {
 }
 
 // Open returns the keyspace with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
+func (s *store) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	ks := &keyspace{
-		Client:    s.client,
-		OnRequest: s.onRequest,
+		Client:    s.Client,
+		OnRequest: s.OnRequest,
 	}
 
 	ks.attr.Keyspace.Value = name
-	ks.prepareRequests(s.table)
+	ks.prepareRequests(s.Table)
 
 	return ks, nil
 }

--- a/driver/aws/dynamoset/doc.go
+++ b/driver/aws/dynamoset/doc.go
@@ -1,3 +1,18 @@
 // Package dynamoset provides a [set.BinaryStore] implementation that persists
 // to a DynamoDB table.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the DynamoDB table:
+//   - dynamodb:DescribeTable
+//   - dynamodb:GetItem
+//   - dynamodb:PutItem
+//   - dynamodb:DeleteItem
+//   - dynamodb:Query
+//
+// If the table does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - dynamodb:CreateTable
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package dynamoset

--- a/driver/aws/dynamoset/doc.go
+++ b/driver/aws/dynamoset/doc.go
@@ -14,5 +14,6 @@
 // automatically, which requires the following additional action:
 //   - dynamodb:CreateTable
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package dynamoset

--- a/driver/aws/dynamoset/schema.go
+++ b/driver/aws/dynamoset/schema.go
@@ -1,9 +1,12 @@
 package dynamoset
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 )
 
 var (
@@ -21,6 +24,35 @@ var (
 	// unnecessary data.
 	nonExistentAttr = "X"
 )
+
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *store) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.Client,
+			s.Table,
+			s.OnRequest,
+			dynamox.KeyAttr{
+				Name:    &setAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &memberAttr,
+				Type:    types.ScalarAttributeTypeB,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
 
 func (s *setimpl) prepareRequests(table string) {
 	key := map[string]types.AttributeValue{

--- a/driver/aws/dynamoset/schema.go
+++ b/driver/aws/dynamoset/schema.go
@@ -1,12 +1,9 @@
 package dynamoset
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 )
 
 var (
@@ -24,26 +21,6 @@ var (
 	// unnecessary data.
 	nonExistentAttr = "X"
 )
-
-// createTable creates the DynamoDB table if it does not already exist.
-func (s *store) createTable(ctx context.Context) error {
-	return dynamox.CreateTableIfNotExists(
-		ctx,
-		s.Client,
-		s.Table,
-		s.OnRequest,
-		dynamox.KeyAttr{
-			Name:    &setAttr,
-			Type:    types.ScalarAttributeTypeS,
-			KeyType: types.KeyTypeHash,
-		},
-		dynamox.KeyAttr{
-			Name:    &memberAttr,
-			Type:    types.ScalarAttributeTypeB,
-			KeyType: types.KeyTypeRange,
-		},
-	)
-}
 
 func (s *setimpl) prepareRequests(table string) {
 	key := map[string]types.AttributeValue{

--- a/driver/aws/dynamoset/store.go
+++ b/driver/aws/dynamoset/store.go
@@ -4,34 +4,35 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
+	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/set"
 )
 
-// BinaryStore is an implementation of [kv.BinaryStore] that persists to a
-// DynamoDB table.
-type store struct {
-	Client    *dynamodb.Client
-	Table     string
-	OnRequest func(any) []func(*dynamodb.Options)
-
-	createTableOnce xsync.SucceedOnce
+// BinaryStore is an implementation of [set.BinaryStore] that persists to a DynamoDB
+// table.
+type BinaryStore struct {
+	client        *dynamodb.Client
+	table         string
+	onRequest     func(any) []func(*dynamodb.Options)
+	provisionOnce xsync.SucceedOnce
 }
 
-// NewBinaryStore returns a new [kv.BinaryStore] that uses the given DynamoDB
-// client to store key/value pairs in the given table.
+// NewBinaryStore returns a new [set.BinaryStore] that uses the given DynamoDB
+// client to store set members in the given table.
 func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) set.BinaryStore {
+) *BinaryStore {
 	if table == "" {
 		panic("table name must not be empty")
 	}
 
-	s := &store{
-		Client: client,
-		Table:  table,
+	s := &BinaryStore{
+		client: client,
+		table:  table,
 	}
 
 	for _, opt := range options {
@@ -42,7 +43,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -54,24 +55,53 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
-// Open returns the keyspace with the given name.
-func (s *store) Open(ctx context.Context, name string) (set.BinarySet, error) {
-	if err := s.createTableOnce.Do(ctx, s.createTable); err != nil {
+// Provision creates the DynamoDB table used by the store if it does not already
+// exist.
+//
+// The store also creates the table on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := dynamox.CreateTableIfNotExists(
+			ctx,
+			s.client,
+			s.table,
+			s.onRequest,
+			dynamox.KeyAttr{
+				Name:    &setAttr,
+				Type:    types.ScalarAttributeTypeS,
+				KeyType: types.KeyTypeHash,
+			},
+			dynamox.KeyAttr{
+				Name:    &memberAttr,
+				Type:    types.ScalarAttributeTypeB,
+				KeyType: types.KeyTypeRange,
+			},
+		)
+		return err
+	})
+}
+
+// Open returns the set with the given name.
+func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, error) {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	set := &setimpl{
-		Client:    s.Client,
-		OnRequest: s.OnRequest,
+		Client:    s.client,
+		OnRequest: s.onRequest,
 	}
 
 	set.attr.Set.Value = name
-	set.prepareRequests(s.Table)
+	set.prepareRequests(s.table)
 
 	return set, nil
 }

--- a/driver/aws/dynamoset/store.go
+++ b/driver/aws/dynamoset/store.go
@@ -10,12 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/set"
 )
 
-// BinaryStore is an implementation of [set.BinaryStore] that persists to a DynamoDB
+// store is an implementation of [set.BinaryStore] that persists to a DynamoDB
 // table.
-type BinaryStore struct {
-	client        *dynamodb.Client
-	table         string
-	onRequest     func(any) []func(*dynamodb.Options)
+type store struct {
+	Client    *dynamodb.Client
+	Table     string
+	OnRequest func(any) []func(*dynamodb.Options)
+
 	provisionOnce xsync.SucceedOnce
 }
 
@@ -25,14 +26,14 @@ func NewBinaryStore(
 	client *dynamodb.Client,
 	table string,
 	options ...Option,
-) *BinaryStore {
+) set.BinaryStore {
 	if table == "" {
 		panic("table name must not be empty")
 	}
 
-	s := &BinaryStore{
-		client: client,
-		table:  table,
+	s := &store{
+		Client: client,
+		Table:  table,
 	}
 
 	for _, opt := range options {
@@ -43,7 +44,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -55,8 +56,8 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
@@ -67,13 +68,13 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 // allows infrastructure to be created ahead of time, for example as part of a
 // deployment pipeline, so that the application itself does not need broad IAM
 // permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
 		_, err := dynamox.CreateTableIfNotExists(
 			ctx,
-			s.client,
-			s.table,
-			s.onRequest,
+			s.Client,
+			s.Table,
+			s.OnRequest,
 			dynamox.KeyAttr{
 				Name:    &setAttr,
 				Type:    types.ScalarAttributeTypeS,
@@ -90,18 +91,18 @@ func (s *BinaryStore) Provision(ctx context.Context) error {
 }
 
 // Open returns the set with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, error) {
+func (s *store) Open(ctx context.Context, name string) (set.BinarySet, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	set := &setimpl{
-		Client:    s.client,
-		OnRequest: s.onRequest,
+		Client:    s.Client,
+		OnRequest: s.OnRequest,
 	}
 
 	set.attr.Set.Value = name
-	set.prepareRequests(s.table)
+	set.prepareRequests(s.Table)
 
 	return set, nil
 }

--- a/driver/aws/dynamoset/store.go
+++ b/driver/aws/dynamoset/store.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/dogmatiq/enginekit/x/xsync"
-	"github.com/dogmatiq/persistencekit/driver/aws/internal/dynamox"
 	"github.com/dogmatiq/persistencekit/set"
 )
 
@@ -59,35 +57,6 @@ func WithRequestHook(fn func(any) []func(*dynamodb.Options)) Option {
 	return func(s *store) {
 		s.OnRequest = fn
 	}
-}
-
-// Provision creates the DynamoDB table used by the store if it does not already
-// exist.
-//
-// The store also creates the table on first use if it does not exist. Provision
-// allows infrastructure to be created ahead of time, for example as part of a
-// deployment pipeline, so that the application itself does not need broad IAM
-// permissions.
-func (s *store) Provision(ctx context.Context) error {
-	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		_, err := dynamox.CreateTableIfNotExists(
-			ctx,
-			s.Client,
-			s.Table,
-			s.OnRequest,
-			dynamox.KeyAttr{
-				Name:    &setAttr,
-				Type:    types.ScalarAttributeTypeS,
-				KeyType: types.KeyTypeHash,
-			},
-			dynamox.KeyAttr{
-				Name:    &memberAttr,
-				Type:    types.ScalarAttributeTypeB,
-				KeyType: types.KeyTypeRange,
-			},
-		)
-		return err
-	})
 }
 
 // Open returns the set with the given name.

--- a/driver/aws/internal/dynamox/table.go
+++ b/driver/aws/internal/dynamox/table.go
@@ -38,10 +38,11 @@ func CreateTableIfNotExists(
 		},
 	)
 	if errors.As(err, new(*types.ResourceNotFoundException)) {
-		if err := createTable(ctx, client, table, onRequest, key); err != nil {
+		var err error
+		created, err = createTable(ctx, client, table, onRequest, key)
+		if err != nil {
 			return false, err
 		}
-		created = true
 	} else if err != nil {
 		return false, fmt.Errorf("unable to describe DynamoDB table: %w", err)
 	} else if res.Table.TableStatus == types.TableStatusActive {
@@ -55,15 +56,15 @@ func CreateTableIfNotExists(
 	return created, nil
 }
 
-// createTable issues a CreateTable request, ignoring ResourceInUseException
-// (which indicates a concurrent creation).
+// createTable issues a CreateTable request. It returns true if the table was
+// created, or false if it already existed due to a concurrent creation.
 func createTable(
 	ctx context.Context,
 	client *dynamodb.Client,
 	table string,
 	onRequest func(any) []func(*dynamodb.Options),
 	key []KeyAttr,
-) error {
+) (bool, error) {
 	req := &dynamodb.CreateTableInput{
 		TableName:   &table,
 		BillingMode: types.BillingModePayPerRequest,
@@ -93,12 +94,13 @@ func createTable(
 		onRequest,
 		req,
 	); err != nil {
-		if !errors.As(err, new(*types.ResourceInUseException)) {
-			return fmt.Errorf("unable to create DynamoDB table: %w", err)
+		if errors.As(err, new(*types.ResourceInUseException)) {
+			return false, nil
 		}
+		return false, fmt.Errorf("unable to create DynamoDB table: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // waitForTable waits for a DynamoDB table to become active.

--- a/driver/aws/internal/dynamox/table.go
+++ b/driver/aws/internal/dynamox/table.go
@@ -103,7 +103,7 @@ func createTable(
 	return true, nil
 }
 
-// waitForTable waits for a DynamoDB table to become active.
+// waitForTable blocks until the given DynamoDB table is created.
 func waitForTable(
 	ctx context.Context,
 	client *dynamodb.Client,

--- a/driver/aws/internal/dynamox/table.go
+++ b/driver/aws/internal/dynamox/table.go
@@ -18,13 +18,51 @@ type KeyAttr struct {
 	KeyType types.KeyType
 }
 
-// CreateTableIfNotExists creates a DynamoDB table if it does not exist.
+// CreateTableIfNotExists creates a DynamoDB table if it does not exist. It
+// returns true if the table was created, or false if it already existed.
 func CreateTableIfNotExists(
 	ctx context.Context,
 	client *dynamodb.Client,
 	table string,
 	onRequest func(any) []func(*dynamodb.Options),
 	key ...KeyAttr,
+) (bool, error) {
+	var created bool
+
+	res, err := awsx.Do(
+		ctx,
+		client.DescribeTable,
+		onRequest,
+		&dynamodb.DescribeTableInput{
+			TableName: &table,
+		},
+	)
+	if errors.As(err, new(*types.ResourceNotFoundException)) {
+		if err := createTable(ctx, client, table, onRequest, key); err != nil {
+			return false, err
+		}
+		created = true
+	} else if err != nil {
+		return false, fmt.Errorf("unable to describe DynamoDB table: %w", err)
+	} else if res.Table.TableStatus == types.TableStatusActive {
+		return false, nil
+	}
+
+	if err := waitForTable(ctx, client, table, onRequest); err != nil {
+		return false, err
+	}
+
+	return created, nil
+}
+
+// createTable issues a CreateTable request, ignoring ResourceInUseException
+// (which indicates a concurrent creation).
+func createTable(
+	ctx context.Context,
+	client *dynamodb.Client,
+	table string,
+	onRequest func(any) []func(*dynamodb.Options),
+	key []KeyAttr,
 ) error {
 	req := &dynamodb.CreateTableInput{
 		TableName:   &table,
@@ -55,12 +93,21 @@ func CreateTableIfNotExists(
 		onRequest,
 		req,
 	); err != nil {
-		if errors.As(err, new(*types.ResourceInUseException)) {
-			return nil
+		if !errors.As(err, new(*types.ResourceInUseException)) {
+			return fmt.Errorf("unable to create DynamoDB table: %w", err)
 		}
-		return fmt.Errorf("unable to create DynamoDB table: %w", err)
 	}
 
+	return nil
+}
+
+// waitForTable waits for a DynamoDB table to become active.
+func waitForTable(
+	ctx context.Context,
+	client *dynamodb.Client,
+	table string,
+	onRequest func(any) []func(*dynamodb.Options),
+) error {
 	in := &dynamodb.DescribeTableInput{
 		TableName: &table,
 	}

--- a/driver/aws/internal/s3x/bucket.go
+++ b/driver/aws/internal/s3x/bucket.go
@@ -9,22 +9,37 @@ import (
 	"github.com/dogmatiq/persistencekit/driver/aws/internal/awsx"
 )
 
-// CreateBucketIfNotExists creates an S3 bucket if it does not already exist.
+// CreateBucketIfNotExists creates an S3 bucket if it does not already exist. It
+// returns true if the bucket was created, or false if it already existed.
 func CreateBucketIfNotExists(
 	ctx context.Context,
 	client *s3.Client,
 	bucket string,
 	onRequest func(any) []func(*s3.Options),
-) error {
-	_, err := awsx.Do(
+) (bool, error) {
+	if _, err := awsx.Do(
+		ctx,
+		client.HeadBucket,
+		onRequest,
+		&s3.HeadBucketInput{
+			Bucket: aws.String(bucket),
+		},
+	); !IsNotExists(err) {
+		return false, err
+	}
+
+	if _, err := awsx.Do(
 		ctx,
 		client.CreateBucket,
 		onRequest,
 		&s3.CreateBucketInput{
 			Bucket: aws.String(bucket),
 		},
-	)
-	return IgnoreAlreadyExists(err)
+	); err != nil {
+		return false, IgnoreAlreadyExists(err)
+	}
+
+	return true, nil
 }
 
 // DeleteBucketIfExists deletes an S3 bucket if it exists.

--- a/driver/aws/s3journal/doc.go
+++ b/driver/aws/s3journal/doc.go
@@ -13,5 +13,6 @@
 // automatically, which requires the following additional action:
 //   - s3:CreateBucket
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package s3journal

--- a/driver/aws/s3journal/doc.go
+++ b/driver/aws/s3journal/doc.go
@@ -1,3 +1,17 @@
 // Package s3journal provides an implementation of [journal.BinaryStore] that
 // persists to an S3 bucket.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the S3 bucket:
+//   - s3:GetObject
+//   - s3:PutObject
+//   - s3:DeleteObject
+//   - s3:ListBucket
+//
+// If the bucket does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - s3:CreateBucket
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package s3journal

--- a/driver/aws/s3journal/store.go
+++ b/driver/aws/s3journal/store.go
@@ -10,14 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/journal"
 )
 
-// store is an implementation of [journal.BinaryStore] that persists to an S3
+// BinaryStore is an implementation of [journal.BinaryStore] that persists to an S3
 // bucket.
-type store struct {
-	Client    *s3.Client
-	Bucket    string
-	OnRequest func(any) []func(*s3.Options)
-
-	createBucketOnce xsync.SucceedOnce
+type BinaryStore struct {
+	client        *s3.Client
+	bucket        string
+	onRequest     func(any) []func(*s3.Options)
+	provisionOnce xsync.SucceedOnce
 }
 
 // NewBinaryStore returns a new [journal.BinaryStore] that uses the given
@@ -26,10 +25,10 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) journal.BinaryStore {
-	s := &store{
-		Client: client,
-		Bucket: bucket,
+) *BinaryStore {
+	s := &BinaryStore{
+		client: client,
+		bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -40,7 +39,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -52,26 +51,40 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
+// Provision creates the S3 bucket used by the store if it does not already
+// exist.
+//
+// The store also creates the bucket on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// broad IAM permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		_, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest)
+		return err
+	})
+}
+
 // Open returns the journal with the given name.
-func (s *store) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
-	if s.Bucket == "" {
+func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
+	if s.bucket == "" {
 		panic("bucket name must not be empty")
 	}
 
-	if err := s.createBucketOnce.Do(ctx, s.createBucket); err != nil {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	j := &journ{
-		client:          s.Client,
-		onRequest:       s.OnRequest,
+		client:          s.client,
+		onRequest:       s.onRequest,
 		name:            name,
-		bucket:          s.Bucket,
+		bucket:          s.bucket,
 		objectKeyPrefix: "journal/" + url.PathEscape(name) + "/",
 	}
 
@@ -84,13 +97,4 @@ func (s *store) Open(ctx context.Context, name string) (journal.BinaryJournal, e
 	}
 
 	return j, nil
-}
-
-func (s *store) createBucket(ctx context.Context) error {
-	return s3x.CreateBucketIfNotExists(
-		ctx,
-		s.Client,
-		s.Bucket,
-		s.OnRequest,
-	)
 }

--- a/driver/aws/s3journal/store.go
+++ b/driver/aws/s3journal/store.go
@@ -10,12 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/journal"
 )
 
-// BinaryStore is an implementation of [journal.BinaryStore] that persists to an S3
+// store is an implementation of [journal.BinaryStore] that persists to an S3
 // bucket.
-type BinaryStore struct {
-	client        *s3.Client
-	bucket        string
-	onRequest     func(any) []func(*s3.Options)
+type store struct {
+	Client    *s3.Client
+	Bucket    string
+	OnRequest func(any) []func(*s3.Options)
+
 	provisionOnce xsync.SucceedOnce
 }
 
@@ -25,10 +26,14 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) *BinaryStore {
-	s := &BinaryStore{
-		client: client,
-		bucket: bucket,
+) journal.BinaryStore {
+	if bucket == "" {
+		panic("bucket name must not be empty")
+	}
+
+	s := &store{
+		Client: client,
+		Bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -39,7 +44,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -51,8 +56,8 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
@@ -63,28 +68,24 @@ func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
 // Provision allows infrastructure to be created ahead of time, for example as
 // part of a deployment pipeline, so that the application itself does not need
 // broad IAM permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		_, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest)
+		_, err := s3x.CreateBucketIfNotExists(ctx, s.Client, s.Bucket, s.OnRequest)
 		return err
 	})
 }
 
 // Open returns the journal with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
-	if s.bucket == "" {
-		panic("bucket name must not be empty")
-	}
-
+func (s *store) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	j := &journ{
-		client:          s.client,
-		onRequest:       s.onRequest,
+		client:          s.Client,
+		onRequest:       s.OnRequest,
 		name:            name,
-		bucket:          s.bucket,
+		bucket:          s.Bucket,
 		objectKeyPrefix: "journal/" + url.PathEscape(name) + "/",
 	}
 

--- a/driver/aws/s3kv/doc.go
+++ b/driver/aws/s3kv/doc.go
@@ -1,3 +1,18 @@
 // Package s3kv provides a [kv.BinaryStore] implementation that persists to an
 // S3 bucket.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the S3 bucket:
+//   - s3:GetObject
+//   - s3:PutObject
+//   - s3:ListBucket
+//
+// If the bucket does not already exist, the store attempts to create it
+// automatically, which requires the following additional actions:
+//   - s3:CreateBucket
+//   - s3:GetLifecycleConfiguration
+//   - s3:PutLifecycleConfiguration
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package s3kv

--- a/driver/aws/s3kv/doc.go
+++ b/driver/aws/s3kv/doc.go
@@ -8,11 +8,16 @@
 //   - s3:PutObject
 //   - s3:ListBucket
 //
-// If the bucket does not already exist, the store attempts to create it
-// automatically, which requires the following additional actions:
-//   - s3:CreateBucket
+// Deleted keys are marked with placeholder objects that are removed
+// automatically by an S3 lifecycle rule. The store ensures this rule is
+// present, which requires the following additional actions:
 //   - s3:GetLifecycleConfiguration
 //   - s3:PutLifecycleConfiguration
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// If the bucket does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - s3:CreateBucket
+//
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package s3kv

--- a/driver/aws/s3kv/store.go
+++ b/driver/aws/s3kv/store.go
@@ -10,13 +10,12 @@ import (
 	"github.com/dogmatiq/persistencekit/kv"
 )
 
-// store is an implementation of [kv.BinaryStore] that persists to an S3 bucket.
-type store struct {
-	Client    *s3.Client
-	Bucket    string
-	OnRequest func(any) []func(*s3.Options)
-
-	createBucketOnce xsync.SucceedOnce
+// BinaryStore is an implementation of [kv.BinaryStore] that persists to an S3 bucket.
+type BinaryStore struct {
+	client        *s3.Client
+	bucket        string
+	onRequest     func(any) []func(*s3.Options)
+	provisionOnce xsync.SucceedOnce
 }
 
 // NewBinaryStore returns a new [kv.BinaryStore] that uses the given S3 client
@@ -25,14 +24,14 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) kv.BinaryStore {
+) *BinaryStore {
 	if bucket == "" {
 		panic("bucket name must not be empty")
 	}
 
-	s := &store{
-		Client: client,
-		Bucket: bucket,
+	s := &BinaryStore{
+		client: client,
+		bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -43,7 +42,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -55,37 +54,40 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
+// Provision creates the S3 bucket and lifecycle rules used by the store if they
+// do not already exist.
+//
+// The store also creates the bucket on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		if _, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest); err != nil {
+			return err
+		}
+		return s3x.EnsureTombstoneLifecycleRule(ctx, s.client, s.bucket, s.onRequest)
+	})
+}
+
 // Open returns the keyspace with the given name.
-func (s *store) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
-	if err := s.createBucketOnce.Do(ctx, s.createBucket); err != nil {
+func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	ks := &keyspace{
-		client:          s.Client,
-		onRequest:       s.OnRequest,
+		client:          s.client,
+		onRequest:       s.onRequest,
 		name:            name,
-		bucket:          s.Bucket,
+		bucket:          s.bucket,
 		objectKeyPrefix: "kv/" + url.PathEscape(name) + "/",
 	}
 
 	return ks, nil
-}
-
-func (s *store) createBucket(ctx context.Context) error {
-	if err := s3x.CreateBucketIfNotExists(
-		ctx,
-		s.Client,
-		s.Bucket,
-		s.OnRequest,
-	); err != nil {
-		return err
-	}
-
-	return s3x.EnsureTombstoneLifecycleRule(ctx, s.Client, s.Bucket, s.OnRequest)
 }

--- a/driver/aws/s3kv/store.go
+++ b/driver/aws/s3kv/store.go
@@ -10,11 +10,12 @@ import (
 	"github.com/dogmatiq/persistencekit/kv"
 )
 
-// BinaryStore is an implementation of [kv.BinaryStore] that persists to an S3 bucket.
-type BinaryStore struct {
-	client        *s3.Client
-	bucket        string
-	onRequest     func(any) []func(*s3.Options)
+// store is an implementation of [kv.BinaryStore] that persists to an S3 bucket.
+type store struct {
+	Client    *s3.Client
+	Bucket    string
+	OnRequest func(any) []func(*s3.Options)
+
 	provisionOnce xsync.SucceedOnce
 }
 
@@ -24,14 +25,14 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) *BinaryStore {
+) kv.BinaryStore {
 	if bucket == "" {
 		panic("bucket name must not be empty")
 	}
 
-	s := &BinaryStore{
-		client: client,
-		bucket: bucket,
+	s := &store{
+		Client: client,
+		Bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -42,7 +43,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -54,38 +55,38 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
 // Provision creates the S3 bucket and lifecycle rules used by the store if they
 // do not already exist.
 //
-// The store also creates the bucket on first use if it does not exist. Provision
-// allows infrastructure to be created ahead of time, for example as part of a
-// deployment pipeline, so that the application itself does not need broad IAM
-// permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+// The store also creates the bucket on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// broad IAM permissions.
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		if _, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest); err != nil {
+		if _, err := s3x.CreateBucketIfNotExists(ctx, s.Client, s.Bucket, s.OnRequest); err != nil {
 			return err
 		}
-		return s3x.EnsureTombstoneLifecycleRule(ctx, s.client, s.bucket, s.onRequest)
+		return s3x.EnsureTombstoneLifecycleRule(ctx, s.Client, s.Bucket, s.OnRequest)
 	})
 }
 
 // Open returns the keyspace with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
+func (s *store) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	ks := &keyspace{
-		client:          s.client,
-		onRequest:       s.onRequest,
+		client:          s.Client,
+		onRequest:       s.OnRequest,
 		name:            name,
-		bucket:          s.bucket,
+		bucket:          s.Bucket,
 		objectKeyPrefix: "kv/" + url.PathEscape(name) + "/",
 	}
 

--- a/driver/aws/s3set/doc.go
+++ b/driver/aws/s3set/doc.go
@@ -1,2 +1,18 @@
-// Package s3set provides a set store backed by AWS S3.
+// Package s3set provides a [set.BinaryStore] implementation that persists to an
+// S3 bucket.
+//
+// # IAM Permissions
+//
+// The following IAM actions are required on the S3 bucket:
+//   - s3:GetObject
+//   - s3:PutObject
+//   - s3:ListBucket
+//
+// If the bucket does not already exist, the store attempts to create it
+// automatically, which requires the following additional actions:
+//   - s3:CreateBucket
+//   - s3:GetLifecycleConfiguration
+//   - s3:PutLifecycleConfiguration
+//
+// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
 package s3set

--- a/driver/aws/s3set/doc.go
+++ b/driver/aws/s3set/doc.go
@@ -8,11 +8,16 @@
 //   - s3:PutObject
 //   - s3:ListBucket
 //
-// If the bucket does not already exist, the store attempts to create it
-// automatically, which requires the following additional actions:
-//   - s3:CreateBucket
+// Removed members are marked with placeholder objects that are removed
+// automatically by an S3 lifecycle rule. The store ensures this rule is
+// present, which requires the following additional actions:
 //   - s3:GetLifecycleConfiguration
 //   - s3:PutLifecycleConfiguration
 //
-// [BinaryStore.Provision] can be called to trigger provisioning ahead of time.
+// If the bucket does not already exist, the store attempts to create it
+// automatically, which requires the following additional action:
+//   - s3:CreateBucket
+//
+// The store's Provision method can be called to trigger provisioning ahead of
+// time.
 package s3set

--- a/driver/aws/s3set/store.go
+++ b/driver/aws/s3set/store.go
@@ -10,13 +10,13 @@ import (
 	"github.com/dogmatiq/persistencekit/set"
 )
 
-// store is an implementation of [set.BinaryStore] that persists to an S3 bucket.
-type store struct {
-	Client    *s3.Client
-	Bucket    string
-	OnRequest func(any) []func(*s3.Options)
+// BinaryStore is an implementation of [set.BinaryStore] that persists to an S3 bucket.
+type BinaryStore struct {
+	client    *s3.Client
+	bucket    string
+	onRequest func(any) []func(*s3.Options)
 
-	createBucketOnce xsync.SucceedOnce
+	provisionOnce xsync.SucceedOnce
 }
 
 // NewBinaryStore returns a new [set.BinaryStore] that uses the given S3 client
@@ -25,14 +25,14 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) set.BinaryStore {
+) *BinaryStore {
 	if bucket == "" {
 		panic("bucket name must not be empty")
 	}
 
-	s := &store{
-		Client: client,
-		Bucket: bucket,
+	s := &BinaryStore{
+		client: client,
+		bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -43,7 +43,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*store)
+type Option func(*BinaryStore)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -55,35 +55,38 @@ type Option func(*store)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *store) {
-		s.OnRequest = fn
+	return func(s *BinaryStore) {
+		s.onRequest = fn
 	}
 }
 
+// Provision creates the S3 bucket and lifecycle rules used by the store if they
+// do not already exist.
+//
+// The store also creates the bucket on first use if it does not exist. Provision
+// allows infrastructure to be created ahead of time, for example as part of a
+// deployment pipeline, so that the application itself does not need broad IAM
+// permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
+		if _, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest); err != nil {
+			return err
+		}
+		return s3x.EnsureTombstoneLifecycleRule(ctx, s.client, s.bucket, s.onRequest)
+	})
+}
+
 // Open returns the set with the given name.
-func (s *store) Open(ctx context.Context, name string) (set.BinarySet, error) {
-	if err := s.createBucketOnce.Do(ctx, s.createBucket); err != nil {
+func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, error) {
+	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	return &setimpl{
-		client:          s.Client,
-		onRequest:       s.OnRequest,
+		client:          s.client,
+		onRequest:       s.onRequest,
 		name:            name,
-		bucket:          s.Bucket,
+		bucket:          s.bucket,
 		objectKeyPrefix: "set/" + url.PathEscape(name) + "/",
 	}, nil
-}
-
-func (s *store) createBucket(ctx context.Context) error {
-	if err := s3x.CreateBucketIfNotExists(
-		ctx,
-		s.Client,
-		s.Bucket,
-		s.OnRequest,
-	); err != nil {
-		return err
-	}
-
-	return s3x.EnsureTombstoneLifecycleRule(ctx, s.Client, s.Bucket, s.OnRequest)
 }

--- a/driver/aws/s3set/store.go
+++ b/driver/aws/s3set/store.go
@@ -10,11 +10,11 @@ import (
 	"github.com/dogmatiq/persistencekit/set"
 )
 
-// BinaryStore is an implementation of [set.BinaryStore] that persists to an S3 bucket.
-type BinaryStore struct {
-	client    *s3.Client
-	bucket    string
-	onRequest func(any) []func(*s3.Options)
+// store is an implementation of [set.BinaryStore] that persists to an S3 bucket.
+type store struct {
+	Client    *s3.Client
+	Bucket    string
+	OnRequest func(any) []func(*s3.Options)
 
 	provisionOnce xsync.SucceedOnce
 }
@@ -25,14 +25,14 @@ func NewBinaryStore(
 	client *s3.Client,
 	bucket string,
 	options ...Option,
-) *BinaryStore {
+) set.BinaryStore {
 	if bucket == "" {
 		panic("bucket name must not be empty")
 	}
 
-	s := &BinaryStore{
-		client: client,
-		bucket: bucket,
+	s := &store{
+		Client: client,
+		Bucket: bucket,
 	}
 
 	for _, opt := range options {
@@ -43,7 +43,7 @@ func NewBinaryStore(
 }
 
 // Option is a functional option that changes the behavior of [NewBinaryStore].
-type Option func(*BinaryStore)
+type Option func(*store)
 
 // WithRequestHook is an [Option] that configures fn as a pre-request hook.
 //
@@ -55,8 +55,8 @@ type Option func(*BinaryStore)
 // Any functions returned by fn will be applied to the request's options before
 // the request is sent.
 func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
-	return func(s *BinaryStore) {
-		s.onRequest = fn
+	return func(s *store) {
+		s.OnRequest = fn
 	}
 }
 
@@ -67,26 +67,26 @@ func WithRequestHook(fn func(any) []func(*s3.Options)) Option {
 // allows infrastructure to be created ahead of time, for example as part of a
 // deployment pipeline, so that the application itself does not need broad IAM
 // permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
+func (s *store) Provision(ctx context.Context) error {
 	return s.provisionOnce.Do(ctx, func(ctx context.Context) error {
-		if _, err := s3x.CreateBucketIfNotExists(ctx, s.client, s.bucket, s.onRequest); err != nil {
+		if _, err := s3x.CreateBucketIfNotExists(ctx, s.Client, s.Bucket, s.OnRequest); err != nil {
 			return err
 		}
-		return s3x.EnsureTombstoneLifecycleRule(ctx, s.client, s.bucket, s.onRequest)
+		return s3x.EnsureTombstoneLifecycleRule(ctx, s.Client, s.Bucket, s.OnRequest)
 	})
 }
 
 // Open returns the set with the given name.
-func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, error) {
+func (s *store) Open(ctx context.Context, name string) (set.BinarySet, error) {
 	if err := s.Provision(ctx); err != nil {
 		return nil, err
 	}
 
 	return &setimpl{
-		client:          s.client,
-		onRequest:       s.onRequest,
+		client:          s.Client,
+		onRequest:       s.OnRequest,
 		name:            name,
-		bucket:          s.bucket,
+		bucket:          s.Bucket,
 		objectKeyPrefix: "set/" + url.PathEscape(name) + "/",
 	}, nil
 }

--- a/driver/memory/memoryjournal/store.go
+++ b/driver/memory/memoryjournal/store.go
@@ -17,6 +17,11 @@ type Store[T any] struct {
 // in memory.
 type BinaryStore = Store[[]byte]
 
+// Provision is a no-op; memory stores do not require provisioning.
+func (s *Store[T]) Provision(ctx context.Context) error {
+	return ctx.Err()
+}
+
 // Open returns the journal with the given name.
 func (s *Store[T]) Open(ctx context.Context, name string) (journal.Journal[T], error) {
 	st, ok := s.journals.Load(name)

--- a/driver/memory/memorykv/store.go
+++ b/driver/memory/memorykv/store.go
@@ -12,6 +12,11 @@ type Store[K comparable, V any] struct {
 	keyspaces sync.Map // map[string]*state[K, V]
 }
 
+// Provision is a no-op; memory stores do not require provisioning.
+func (s *Store[K, V]) Provision(ctx context.Context) error {
+	return ctx.Err()
+}
+
 // Open returns the keyspace with the given name.
 func (s *Store[K, V]) Open(ctx context.Context, name string) (kv.Keyspace[K, V], error) {
 	st, ok := s.keyspaces.Load(name)
@@ -39,6 +44,11 @@ func identity[K any](k K) K {
 // records in memory.
 type BinaryStore struct {
 	keyspaces sync.Map // map[string]*state[string, []byte]
+}
+
+// Provision is a no-op; memory stores do not require provisioning.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return ctx.Err()
 }
 
 // Open returns the keyspace with the given name.

--- a/driver/memory/memoryset/store.go
+++ b/driver/memory/memoryset/store.go
@@ -12,6 +12,11 @@ type Store[T comparable] struct {
 	state sync.Map // map[string]*state[T]
 }
 
+// Provision is a no-op; memory stores do not require provisioning.
+func (s *Store[T]) Provision(ctx context.Context) error {
+	return ctx.Err()
+}
+
 // Open returns the set with the given name.
 func (s *Store[T]) Open(ctx context.Context, name string) (set.Set[T], error) {
 	st, ok := s.state.Load(name)
@@ -39,6 +44,11 @@ func identity[K any](k K) K {
 // sets in memory.
 type BinaryStore struct {
 	state sync.Map // map[string]*state[string]
+}
+
+// Provision is a no-op; memory stores do not require provisioning.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return ctx.Err()
 }
 
 // Open returns the keyspace with the given name.

--- a/driver/sql/postgres/pgjournal/schema.go
+++ b/driver/sql/postgres/pgjournal/schema.go
@@ -11,14 +11,17 @@ import (
 //go:embed schema.sql
 var schema string
 
-// createSchema creates the PostgreSQL schema elements required by [BinaryStore].
-func createSchema(
-	ctx context.Context,
-	db *sql.DB,
-) error {
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
 	return pgerror.Retry(
 		ctx,
-		db,
+		s.DB,
 		func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, schema)
 			return err

--- a/driver/sql/postgres/pgjournal/store.go
+++ b/driver/sql/postgres/pgjournal/store.go
@@ -12,13 +12,13 @@ import (
 // BinaryStore is an implementation of [journal.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	db *sql.DB
+	DB *sql.DB
 }
 
 // NewBinaryStore returns a new [journal.BinaryStore] that persists to the given
 // PostgreSQL database.
 func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{db: db}
+	return &BinaryStore{DB: db}
 }
 
 // Provision creates the PostgreSQL schema and tables used by the store if they
@@ -29,7 +29,7 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 // part of a deployment pipeline, so that the application itself does not need
 // DDL permissions.
 func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.db)
+	return createSchema(ctx, s.DB)
 }
 
 // Open returns the journal with the given name.
@@ -38,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJour
 	if err != nil {
 		return nil, err
 	}
-	return &journ{s.db, id, name}, nil
+	return &journ{s.DB, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.db.QueryRowContext(
+		row := s.DB.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.journal (
 				name
@@ -66,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan journal ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.db); err != nil {
+		if err := createSchema(ctx, s.DB); err != nil {
 			return 0, fmt.Errorf("cannot create journal schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgjournal/store.go
+++ b/driver/sql/postgres/pgjournal/store.go
@@ -21,17 +21,6 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 	return &BinaryStore{DB: db}
 }
 
-// Provision creates the PostgreSQL schema and tables used by the store if they
-// do not already exist.
-//
-// The store also creates the schema on first use if it does not exist.
-// Provision allows infrastructure to be created ahead of time, for example as
-// part of a deployment pipeline, so that the application itself does not need
-// DDL permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.DB)
-}
-
 // Open returns the journal with the given name.
 func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJournal, error) {
 	id, err := s.getID(ctx, name)
@@ -66,7 +55,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan journal ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := s.Provision(ctx); err != nil {
 			return 0, fmt.Errorf("cannot create journal schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgjournal/store.go
+++ b/driver/sql/postgres/pgjournal/store.go
@@ -12,8 +12,24 @@ import (
 // BinaryStore is an implementation of [journal.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	// DB is the PostgreSQL database connection.
-	DB *sql.DB
+	db *sql.DB
+}
+
+// NewBinaryStore returns a new [journal.BinaryStore] that persists to the given
+// PostgreSQL database.
+func NewBinaryStore(db *sql.DB) *BinaryStore {
+	return &BinaryStore{db: db}
+}
+
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return createSchema(ctx, s.db)
 }
 
 // Open returns the journal with the given name.
@@ -22,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (journal.BinaryJour
 	if err != nil {
 		return nil, err
 	}
-	return &journ{s.DB, id, name}, nil
+	return &journ{s.db, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.DB.QueryRowContext(
+		row := s.db.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.journal (
 				name
@@ -50,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan journal ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := createSchema(ctx, s.db); err != nil {
 			return 0, fmt.Errorf("cannot create journal schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgjournal/store.go
+++ b/driver/sql/postgres/pgjournal/store.go
@@ -12,13 +12,8 @@ import (
 // BinaryStore is an implementation of [journal.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
+	// DB is the PostgreSQL database connection.
 	DB *sql.DB
-}
-
-// NewBinaryStore returns a new [journal.BinaryStore] that persists to the given
-// PostgreSQL database.
-func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{DB: db}
 }
 
 // Open returns the journal with the given name.

--- a/driver/sql/postgres/pgjournal/store_test.go
+++ b/driver/sql/postgres/pgjournal/store_test.go
@@ -12,7 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	journal.RunTests(
 		t,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }
 
@@ -20,6 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	journal.RunBenchmarks(
 		b,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }

--- a/driver/sql/postgres/pgjournal/store_test.go
+++ b/driver/sql/postgres/pgjournal/store_test.go
@@ -12,9 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	journal.RunTests(
 		t,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }
 
@@ -22,8 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	journal.RunBenchmarks(
 		b,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }

--- a/driver/sql/postgres/pgjournal/store_test.go
+++ b/driver/sql/postgres/pgjournal/store_test.go
@@ -12,7 +12,9 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	journal.RunTests(
 		t,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }
 
@@ -20,6 +22,8 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	journal.RunBenchmarks(
 		b,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }

--- a/driver/sql/postgres/pgkv/schema.go
+++ b/driver/sql/postgres/pgkv/schema.go
@@ -11,14 +11,17 @@ import (
 //go:embed schema.sql
 var schema string
 
-// createSchema creates the PostgreSQL schema elements required by [BinaryStore].
-func createSchema(
-	ctx context.Context,
-	db *sql.DB,
-) error {
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
 	return pgerror.Retry(
 		ctx,
-		db,
+		s.DB,
 		func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, schema)
 			return err

--- a/driver/sql/postgres/pgkv/store.go
+++ b/driver/sql/postgres/pgkv/store.go
@@ -21,17 +21,6 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 	return &BinaryStore{DB: db}
 }
 
-// Provision creates the PostgreSQL schema and tables used by the store if they
-// do not already exist.
-//
-// The store also creates the schema on first use if it does not exist.
-// Provision allows infrastructure to be created ahead of time, for example as
-// part of a deployment pipeline, so that the application itself does not need
-// DDL permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.DB)
-}
-
 // Open returns the keyspace with the given name.
 func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace, error) {
 	id, err := s.getID(ctx, name)
@@ -66,7 +55,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan keyspace ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := s.Provision(ctx); err != nil {
 			return 0, fmt.Errorf("cannot create keyspace schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgkv/store.go
+++ b/driver/sql/postgres/pgkv/store.go
@@ -12,7 +12,24 @@ import (
 // BinaryStore is an implementation of [kv.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	DB *sql.DB
+	db *sql.DB
+}
+
+// NewBinaryStore returns a new [kv.BinaryStore] that persists to the given
+// PostgreSQL database.
+func NewBinaryStore(db *sql.DB) *BinaryStore {
+	return &BinaryStore{db: db}
+}
+
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return createSchema(ctx, s.db)
 }
 
 // Open returns the keyspace with the given name.
@@ -21,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace,
 	if err != nil {
 		return nil, err
 	}
-	return &keyspace{s.DB, id, name}, nil
+	return &keyspace{s.db, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.DB.QueryRowContext(
+		row := s.db.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.keyspace (
 				name
@@ -49,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan keyspace ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := createSchema(ctx, s.db); err != nil {
 			return 0, fmt.Errorf("cannot create keyspace schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgkv/store.go
+++ b/driver/sql/postgres/pgkv/store.go
@@ -12,13 +12,8 @@ import (
 // BinaryStore is an implementation of [kv.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
+	// DB is the PostgreSQL database connection.
 	DB *sql.DB
-}
-
-// NewBinaryStore returns a new [kv.BinaryStore] that persists to the given
-// PostgreSQL database.
-func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{DB: db}
 }
 
 // Open returns the keyspace with the given name.

--- a/driver/sql/postgres/pgkv/store.go
+++ b/driver/sql/postgres/pgkv/store.go
@@ -12,13 +12,13 @@ import (
 // BinaryStore is an implementation of [kv.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	db *sql.DB
+	DB *sql.DB
 }
 
 // NewBinaryStore returns a new [kv.BinaryStore] that persists to the given
 // PostgreSQL database.
 func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{db: db}
+	return &BinaryStore{DB: db}
 }
 
 // Provision creates the PostgreSQL schema and tables used by the store if they
@@ -29,7 +29,7 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 // part of a deployment pipeline, so that the application itself does not need
 // DDL permissions.
 func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.db)
+	return createSchema(ctx, s.DB)
 }
 
 // Open returns the keyspace with the given name.
@@ -38,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (kv.BinaryKeyspace,
 	if err != nil {
 		return nil, err
 	}
-	return &keyspace{s.db, id, name}, nil
+	return &keyspace{s.DB, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.db.QueryRowContext(
+		row := s.DB.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.keyspace (
 				name
@@ -66,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan keyspace ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.db); err != nil {
+		if err := createSchema(ctx, s.DB); err != nil {
 			return 0, fmt.Errorf("cannot create keyspace schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgkv/store_test.go
+++ b/driver/sql/postgres/pgkv/store_test.go
@@ -12,7 +12,9 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	kv.RunTests(
 		t,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }
 
@@ -20,6 +22,8 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	kv.RunBenchmarks(
 		b,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }

--- a/driver/sql/postgres/pgkv/store_test.go
+++ b/driver/sql/postgres/pgkv/store_test.go
@@ -12,9 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	kv.RunTests(
 		t,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }
 
@@ -22,8 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	kv.RunBenchmarks(
 		b,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }

--- a/driver/sql/postgres/pgkv/store_test.go
+++ b/driver/sql/postgres/pgkv/store_test.go
@@ -12,7 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	kv.RunTests(
 		t,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }
 
@@ -20,6 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	kv.RunBenchmarks(
 		b,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }

--- a/driver/sql/postgres/pgset/schema.go
+++ b/driver/sql/postgres/pgset/schema.go
@@ -11,14 +11,17 @@ import (
 //go:embed schema.sql
 var schema string
 
-// createSchema creates the PostgreSQL schema elements required by [BinaryStore].
-func createSchema(
-	ctx context.Context,
-	db *sql.DB,
-) error {
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
 	return pgerror.Retry(
 		ctx,
-		db,
+		s.DB,
 		func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, schema)
 			return err

--- a/driver/sql/postgres/pgset/store.go
+++ b/driver/sql/postgres/pgset/store.go
@@ -21,17 +21,6 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 	return &BinaryStore{DB: db}
 }
 
-// Provision creates the PostgreSQL schema and tables used by the store if they
-// do not already exist.
-//
-// The store also creates the schema on first use if it does not exist.
-// Provision allows infrastructure to be created ahead of time, for example as
-// part of a deployment pipeline, so that the application itself does not need
-// DDL permissions.
-func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.DB)
-}
-
 // Open returns the set with the given name.
 func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, error) {
 	id, err := s.getID(ctx, name)
@@ -66,7 +55,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan set ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := s.Provision(ctx); err != nil {
 			return 0, fmt.Errorf("cannot create set schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgset/store.go
+++ b/driver/sql/postgres/pgset/store.go
@@ -12,7 +12,24 @@ import (
 // BinaryStore is an implementation of [set.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	DB *sql.DB
+	db *sql.DB
+}
+
+// NewBinaryStore returns a new [set.BinaryStore] that persists to the given
+// PostgreSQL database.
+func NewBinaryStore(db *sql.DB) *BinaryStore {
+	return &BinaryStore{db: db}
+}
+
+// Provision creates the PostgreSQL schema and tables used by the store if they
+// do not already exist.
+//
+// The store also creates the schema on first use if it does not exist.
+// Provision allows infrastructure to be created ahead of time, for example as
+// part of a deployment pipeline, so that the application itself does not need
+// DDL permissions.
+func (s *BinaryStore) Provision(ctx context.Context) error {
+	return createSchema(ctx, s.db)
 }
 
 // Open returns the set with the given name.
@@ -21,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, err
 	if err != nil {
 		return nil, err
 	}
-	return &setimpl{s.DB, id, name}, nil
+	return &setimpl{s.db, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.DB.QueryRowContext(
+		row := s.db.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.set (
 				name
@@ -49,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan set ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.DB); err != nil {
+		if err := createSchema(ctx, s.db); err != nil {
 			return 0, fmt.Errorf("cannot create set schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgset/store.go
+++ b/driver/sql/postgres/pgset/store.go
@@ -12,13 +12,13 @@ import (
 // BinaryStore is an implementation of [set.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
-	db *sql.DB
+	DB *sql.DB
 }
 
 // NewBinaryStore returns a new [set.BinaryStore] that persists to the given
 // PostgreSQL database.
 func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{db: db}
+	return &BinaryStore{DB: db}
 }
 
 // Provision creates the PostgreSQL schema and tables used by the store if they
@@ -29,7 +29,7 @@ func NewBinaryStore(db *sql.DB) *BinaryStore {
 // part of a deployment pipeline, so that the application itself does not need
 // DDL permissions.
 func (s *BinaryStore) Provision(ctx context.Context) error {
-	return createSchema(ctx, s.db)
+	return createSchema(ctx, s.DB)
 }
 
 // Open returns the set with the given name.
@@ -38,12 +38,12 @@ func (s *BinaryStore) Open(ctx context.Context, name string) (set.BinarySet, err
 	if err != nil {
 		return nil, err
 	}
-	return &setimpl{s.db, id, name}, nil
+	return &setimpl{s.DB, id, name}, nil
 }
 
 func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 	for {
-		row := s.db.QueryRowContext(
+		row := s.DB.QueryRowContext(
 			ctx,
 			`INSERT INTO persistencekit.set (
 				name
@@ -66,7 +66,7 @@ func (s *BinaryStore) getID(ctx context.Context, name string) (uint64, error) {
 			return 0, fmt.Errorf("cannot scan set ID: %w", err)
 		}
 
-		if err := createSchema(ctx, s.db); err != nil {
+		if err := createSchema(ctx, s.DB); err != nil {
 			return 0, fmt.Errorf("cannot create set schema: %w", err)
 		}
 	}

--- a/driver/sql/postgres/pgset/store.go
+++ b/driver/sql/postgres/pgset/store.go
@@ -12,13 +12,8 @@ import (
 // BinaryStore is an implementation of [set.BinaryStore] that persists to a
 // PostgreSQL database.
 type BinaryStore struct {
+	// DB is the PostgreSQL database connection.
 	DB *sql.DB
-}
-
-// NewBinaryStore returns a new [set.BinaryStore] that persists to the given
-// PostgreSQL database.
-func NewBinaryStore(db *sql.DB) *BinaryStore {
-	return &BinaryStore{DB: db}
 }
 
 // Open returns the set with the given name.

--- a/driver/sql/postgres/pgset/store_test.go
+++ b/driver/sql/postgres/pgset/store_test.go
@@ -12,9 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	set.RunTests(
 		t,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }
 
@@ -22,8 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	set.RunBenchmarks(
 		b,
-		&BinaryStore{
-			DB: db,
-		},
+		NewBinaryStore(db),
 	)
 }

--- a/driver/sql/postgres/pgset/store_test.go
+++ b/driver/sql/postgres/pgset/store_test.go
@@ -12,7 +12,7 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	set.RunTests(
 		t,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }
 
@@ -20,6 +20,6 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	set.RunBenchmarks(
 		b,
-		NewBinaryStore(db),
+		&BinaryStore{DB: db},
 	)
 }

--- a/driver/sql/postgres/pgset/store_test.go
+++ b/driver/sql/postgres/pgset/store_test.go
@@ -12,7 +12,9 @@ func TestStore(t *testing.T) {
 	db := pgtest.Setup(t)
 	set.RunTests(
 		t,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }
 
@@ -20,6 +22,8 @@ func BenchmarkStore(b *testing.B) {
 	db := pgtest.Setup(b)
 	set.RunBenchmarks(
 		b,
-		&BinaryStore{DB: db},
+		&BinaryStore{
+			DB: db,
+		},
 	)
 }

--- a/journal/interceptor.go
+++ b/journal/interceptor.go
@@ -48,6 +48,10 @@ type interceptedStore[T any] struct {
 	Interceptor *Interceptor[T]
 }
 
+func (s *interceptedStore[T]) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 func (s *interceptedStore[T]) Open(ctx context.Context, name string) (Journal[T], error) {
 	if fn := s.Interceptor.beforeOpen.Load(); fn != nil {
 		if err := fn(name); err != nil {

--- a/journal/store.go
+++ b/journal/store.go
@@ -6,5 +6,10 @@ import (
 
 // Store is a collection of journals containing records of type T.
 type Store[T any] interface {
+	// Open returns the journal with the given name.
 	Open(ctx context.Context, name string) (Journal[T], error)
+
+	// Provision creates the infrastructure used by the store if it does not
+	// already exist.
+	Provision(ctx context.Context) error
 }

--- a/journal/telemetry.go
+++ b/journal/telemetry.go
@@ -33,6 +33,10 @@ type instrumentedStore struct {
 	Telemetry telemetry.Provider
 }
 
+func (s *instrumentedStore) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 // Open returns the journal with the given name.
 func (s *instrumentedStore) Open(ctx context.Context, name string) (BinaryJournal, error) {
 	telem := s.Telemetry.Recorder(

--- a/kv/interceptor.go
+++ b/kv/interceptor.go
@@ -46,6 +46,10 @@ type interceptedStore[K, V any] struct {
 	Interceptor *Interceptor[K, V]
 }
 
+func (s *interceptedStore[K, V]) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 func (s *interceptedStore[K, V]) Open(ctx context.Context, name string) (Keyspace[K, V], error) {
 	if fn := s.Interceptor.beforeOpen.Load(); fn != nil {
 		if err := fn(name); err != nil {

--- a/kv/store.go
+++ b/kv/store.go
@@ -9,4 +9,8 @@ import (
 type Store[K, V any] interface {
 	// Open returns the keyspace with the given name.
 	Open(ctx context.Context, name string) (Keyspace[K, V], error)
+
+	// Provision creates the infrastructure used by the store if it does not
+	// already exist.
+	Provision(ctx context.Context) error
 }

--- a/kv/telemetry.go
+++ b/kv/telemetry.go
@@ -33,6 +33,10 @@ type instrumentedStore struct {
 	Telemetry telemetry.Provider
 }
 
+func (s *instrumentedStore) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 // Open returns the keyspace with the given name.
 func (s *instrumentedStore) Open(ctx context.Context, name string) (BinaryKeyspace, error) {
 	telem := s.Telemetry.Recorder(

--- a/set/interceptor.go
+++ b/set/interceptor.go
@@ -62,6 +62,10 @@ type interceptedStore[T any] struct {
 	Interceptor *Interceptor[T]
 }
 
+func (s *interceptedStore[T]) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 func (s *interceptedStore[T]) Open(ctx context.Context, name string) (Set[T], error) {
 	if fn := s.Interceptor.beforeOpen.Load(); fn != nil {
 		if err := fn(name); err != nil {

--- a/set/store.go
+++ b/set/store.go
@@ -8,4 +8,8 @@ import (
 type Store[T any] interface {
 	// Open returns the set with the given name.
 	Open(ctx context.Context, name string) (Set[T], error)
+
+	// Provision creates the infrastructure used by the store if it does not
+	// already exist.
+	Provision(ctx context.Context) error
 }

--- a/set/telemetry.go
+++ b/set/telemetry.go
@@ -33,6 +33,10 @@ type instrumentedStore struct {
 	Telemetry telemetry.Provider
 }
 
+func (s *instrumentedStore) Provision(ctx context.Context) error {
+	return s.Next.Provision(ctx)
+}
+
 // Open returns the set with the given name.
 func (s *instrumentedStore) Open(ctx context.Context, name string) (BinarySet, error) {
 	telem := s.Telemetry.Recorder(


### PR DESCRIPTION
Add a `Provision(ctx context.Context) error` method to the `journal.Store`, `kv.Store`, and `set.Store` interfaces, allowing callers to trigger infrastructure provisioning ahead of time — for example, during a deployment pipeline — so that the application itself does not need broad IAM or DDL permissions at runtime.

## Changes

### Store interfaces
- Added `Provision(ctx context.Context) error` to `journal.Store[T]`, `kv.Store[K,V]`, and `set.Store[T]`

### AWS drivers (s3journal, s3kv, s3set, dynamojournal, dynamokv, dynamoset)
- Added `Provision()` method using `xsync.SucceedOnce` for lazy one-shot provisioning
- `Open()` delegates to `Provision()` so infrastructure is created automatically on first use
- Inlined bucket/table creation into `Provision()` closures
- `NewBinaryStore()` returns the interface type instead of the concrete type
- Added empty-string validation to constructors for bucket/table names
- Updated doc.go IAM permission sections
- Clarified lifecycle rule documentation in s3kv and s3set

### Postgres drivers (pgjournal, pgkv, pgset)
- Added `NewBinaryStore(db *sql.DB)` constructor (existing struct literal construction via exported `DB` field still works)
- Replaced standalone `ProvisionInfrastructure(ctx, db)` with `BinaryStore.Provision(ctx)`
- Deleted `provision.go` files

### Memory drivers
- Added no-op `Provision()` returning `ctx.Err()`

### Wrappers (interceptor, telemetry, marshal, nametransform)
- Interceptor and telemetry wrappers delegate `Provision()` to their underlying store
- Marshal and nametransform wrappers inherit `Provision()` via embedding

### Internal helpers
- `dynamox.CreateTableIfNotExists()` now returns `(bool, error)` indicating whether the table was created
- `s3x.CreateBucketIfNotExists()` now returns `(bool, error)` indicating whether the bucket was created

Closes #751