### PR TITLE
Eliminate Config adaptor layer

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -5,35 +5,18 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/dogmatiq/persistencekit/driver"
 	"github.com/dogmatiq/persistencekit/driver/aws/dynamodb"
 	"github.com/dogmatiq/persistencekit/driver/aws/s3"
 	"github.com/dogmatiq/persistencekit/driver/memory"
 	"github.com/dogmatiq/persistencekit/driver/sql/postgres"
-	"github.com/dogmatiq/persistencekit/journal"
-	"github.com/dogmatiq/persistencekit/kv"
-	"github.com/dogmatiq/persistencekit/set"
 )
 
 // Driver provides access to the persistence stores of a specific driver.
-type Driver interface {
-	// JournalStore returns the journal store provided by this driver.
-	JournalStore() journal.BinaryStore
-
-	// KVStore returns the key/value store provided by this driver.
-	KVStore() kv.BinaryStore
-
-	// SetStore returns the set store provided by this driver.
-	SetStore() set.BinaryStore
-
-	// Close closes the driver, releasing any resources.
-	Close() error
-}
+type Driver = driver.Driver
 
 // Config describes the connection parameters for a persistence driver.
-type Config interface {
-	// NewDriver creates a new [Driver] using this configuration.
-	NewDriver(context.Context) (Driver, error)
-}
+type Config = driver.Config
 
 // ParseURL parses a driver URL string and returns a [Config] for the backend
 // identified by the URL scheme.
@@ -89,41 +72,16 @@ func ParseURL(ctx context.Context, u string) (Config, error) {
 func FromURL(ctx context.Context, u *url.URL) (Config, error) {
 	switch u.Scheme {
 	case "memory":
-		return asInterface(memory.FromURL(ctx, u))
+		return memory.FromURL(ctx, u)
 	case "postgres", "postgresql":
-		return asInterface(postgres.FromURL(ctx, u))
+		return postgres.FromURL(ctx, u)
 	case "dynamodb":
-		return asInterface(dynamodb.FromURL(ctx, u))
+		return dynamodb.FromURL(ctx, u)
 	case "s3":
-		return asInterface(s3.FromURL(ctx, u))
+		return s3.FromURL(ctx, u)
 	case "":
 		return nil, fmt.Errorf("persistence driver URL has no scheme: %q", u)
 	default:
 		return nil, fmt.Errorf("unsupported persistence driver scheme %q", u.Scheme)
 	}
-}
-
-// config is the constraint satisfied by per-driver *Config types whose
-// NewDriver method returns a concrete *Driver rather than the [Driver]
-// interface.
-type config[T Driver] interface {
-	NewDriver(context.Context) (T, error)
-}
-
-// asInterface adapts a driver-specific [config] to the generic [Config]
-// interface.
-func asInterface[T Driver](cfg config[T], err error) (Config, error) {
-	if err != nil {
-		return nil, err
-	}
-
-	return &configAdapter[T]{cfg}, nil
-}
-
-type configAdapter[T Driver] struct {
-	cfg config[T]
-}
-
-func (a *configAdapter[T]) NewDriver(ctx context.Context) (Driver, error) {
-	return a.cfg.NewDriver(ctx)
 }

--- a/driver/aws/dynamodb/driver.go
+++ b/driver/aws/dynamodb/driver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/dogmatiq/persistencekit/driver"
 	"github.com/dogmatiq/persistencekit/driver/aws/dynamodb/dynamojournal"
 	"github.com/dogmatiq/persistencekit/driver/aws/dynamodb/dynamokv"
 	"github.com/dogmatiq/persistencekit/driver/aws/dynamodb/dynamoset"
@@ -24,8 +25,17 @@ type Driver struct {
 	client      *awsdynamodb.Client
 }
 
-// New returns a [Driver] that uses the given DynamoDB client and table prefix.
-func New(client *awsdynamodb.Client, tablePrefix string) *Driver {
+// New returns a [Driver] described by the given configuration.
+func New(cfg *Config) *Driver {
+	return NewFromClient(
+		awsdynamodb.NewFromConfig(cfg.AWS, cfg.ClientOptions...),
+		cfg.TablePrefix,
+	)
+}
+
+// NewFromClient returns a [Driver] that uses a pre-built DynamoDB client and
+// table prefix. The caller retains ownership of the client.
+func NewFromClient(client *awsdynamodb.Client, tablePrefix string) *Driver {
 	return &Driver{
 		client:      client,
 		tablePrefix: tablePrefix,
@@ -45,20 +55,21 @@ type Config struct {
 	TablePrefix string
 }
 
-// NewDriver creates a [Driver] using the configured AWS settings.
-func (c *Config) NewDriver(context.Context) (*Driver, error) {
-	return &Driver{
-		tablePrefix: c.TablePrefix,
-		client:      awsdynamodb.NewFromConfig(c.AWS, c.ClientOptions...),
-	}, nil
+// NewDriver returns a [Driver] described by the given configuration.
+func (c *Config) NewDriver(context.Context) (driver.Driver, error) {
+	return New(c), nil
 }
 
-// ParseURL returns a [*Config] for the given dynamodb:// URL string.
+// ParseURL returns a [Config] for the given URL string.
 //
 // URL format:
 //
 //	dynamodb:///<table-prefix>
 //	dynamodb://<host>:<port>/<table-prefix>
+//
+// The table prefix is prepended to the names of each DynamoDB table. Each
+// primitive uses a separate table ("<prefix>-journal", "<prefix>-kv",
+// "<prefix>-set"). If a host is specified, it is used as a custom endpoint.
 //
 // Supported query parameters:
 //   - region: AWS region (e.g. "us-east-1"); if omitted, resolved from the environment
@@ -72,8 +83,9 @@ func ParseURL(ctx context.Context, u string) (*Config, error) {
 	return FromURL(ctx, parsed)
 }
 
-// FromURL returns a [*Config] for the given dynamodb:// [*url.URL]. See
-// [ParseURL] for the URL format.
+// FromURL returns a [Config] for the given URL.
+//
+// See [ParseURL] for the URL format.
 func FromURL(ctx context.Context, u *url.URL) (*Config, error) {
 	if u.Scheme != "dynamodb" {
 		return nil, fmt.Errorf("invalid dynamodb URL: unexpected scheme %q", u.Scheme)

--- a/driver/aws/dynamodb/driver_test.go
+++ b/driver/aws/dynamodb/driver_test.go
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 	client, _ := xdynamodb.NewTestClient(t)
 	xdynamodb.CleanupTable(t, client, journalTable, kvTable, setTable)
 
-	d := dynamodb.New(client, tablePrefix)
+	d := dynamodb.NewFromClient(client, tablePrefix)
 	t.Cleanup(func() {
 		d.Close()
 	})

--- a/driver/aws/s3/driver.go
+++ b/driver/aws/s3/driver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/dogmatiq/persistencekit/driver"
 	"github.com/dogmatiq/persistencekit/driver/aws/internal/x/xaws"
 	"github.com/dogmatiq/persistencekit/driver/aws/s3/s3journal"
 	"github.com/dogmatiq/persistencekit/driver/aws/s3/s3kv"
@@ -24,8 +25,17 @@ type Driver struct {
 	client *awss3.Client
 }
 
-// New returns a [Driver] that uses the given S3 client and bucket.
-func New(client *awss3.Client, bucket string) *Driver {
+// New returns a [Driver] described by the given configuration.
+func New(cfg *Config) *Driver {
+	return NewFromClient(
+		awss3.NewFromConfig(cfg.AWS, cfg.ClientOptions...),
+		cfg.Bucket,
+	)
+}
+
+// NewFromClient returns a [Driver] that uses a pre-built S3 client and bucket.
+// The caller retains ownership of the client.
+func NewFromClient(client *awss3.Client, bucket string) *Driver {
 	return &Driver{
 		client: client,
 		bucket: bucket,
@@ -44,20 +54,20 @@ type Config struct {
 	Bucket string
 }
 
-// NewDriver creates a [Driver] using the configured AWS settings.
-func (c *Config) NewDriver(context.Context) (*Driver, error) {
-	return &Driver{
-		bucket: c.Bucket,
-		client: awss3.NewFromConfig(c.AWS, c.ClientOptions...),
-	}, nil
+// NewDriver returns a [Driver] described by the given configuration.
+func (c *Config) NewDriver(context.Context) (driver.Driver, error) {
+	return New(c), nil
 }
 
-// ParseURL returns a [*Config] for the given s3:// URL string.
+// ParseURL returns a [Config] for the given URL string.
 //
 // URL format:
 //
 //	s3:///<bucket>
 //	s3://<endpoint>/<bucket>
+//
+// The bucket is the name of the S3 bucket. If an endpoint is specified, it is
+// used as a custom S3-compatible endpoint and path-style addressing is enabled.
 //
 // Supported query parameters:
 //   - region: AWS region (e.g. "us-east-1"); if omitted, resolved from the environment
@@ -71,8 +81,9 @@ func ParseURL(ctx context.Context, u string) (*Config, error) {
 	return FromURL(ctx, parsed)
 }
 
-// FromURL returns a [*Config] for the given s3:// [*url.URL]. See [ParseURL]
-// for the URL format.
+// FromURL returns a [Config] for the given URL.
+//
+// See [ParseURL] for the URL format.
 func FromURL(ctx context.Context, u *url.URL) (*Config, error) {
 	if u.Scheme != "s3" {
 		return nil, fmt.Errorf("invalid s3 URL: unexpected scheme %q", u.Scheme)

--- a/driver/aws/s3/driver_test.go
+++ b/driver/aws/s3/driver_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 	bucket := xtesting.UniqueName("new")
 	xs3.CleanupBucket(t, client, bucket)
 
-	d := s3.New(client, bucket)
+	d := s3.NewFromClient(client, bucket)
 	t.Cleanup(func() {
 		d.Close()
 	})

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,0 +1,31 @@
+// Package driver defines the interfaces implemented by persistence drivers.
+package driver
+
+import (
+	"context"
+
+	"github.com/dogmatiq/persistencekit/journal"
+	"github.com/dogmatiq/persistencekit/kv"
+	"github.com/dogmatiq/persistencekit/set"
+)
+
+// Driver provides access to the persistence stores of a specific driver.
+type Driver interface {
+	// JournalStore returns the journal store provided by this driver.
+	JournalStore() journal.BinaryStore
+
+	// KVStore returns the key/value store provided by this driver.
+	KVStore() kv.BinaryStore
+
+	// SetStore returns the set store provided by this driver.
+	SetStore() set.BinaryStore
+
+	// Close closes the driver, releasing any resources.
+	Close() error
+}
+
+// Config describes the connection parameters for a persistence driver.
+type Config interface {
+	// NewDriver creates a new [Driver] using this configuration.
+	NewDriver(context.Context) (Driver, error)
+}

--- a/driver/memory/driver.go
+++ b/driver/memory/driver.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dogmatiq/persistencekit/driver"
 	"github.com/dogmatiq/persistencekit/driver/memory/memoryjournal"
 	"github.com/dogmatiq/persistencekit/driver/memory/memorykv"
 	"github.com/dogmatiq/persistencekit/driver/memory/memoryset"
@@ -28,9 +29,9 @@ type Driver struct {
 	silo *silo
 }
 
-// New returns a [Driver] backed by the named silo.
-func New(name string) *Driver {
-	v, _ := silos.LoadOrStore(name, &silo{})
+// New returns a [Driver] described by the given configuration.
+func New(cfg *Config) *Driver {
+	v, _ := silos.LoadOrStore(cfg.Silo, &silo{})
 	return &Driver{silo: v.(*silo)}
 }
 
@@ -41,16 +42,19 @@ type Config struct {
 	Silo string
 }
 
-// NewDriver returns a [Driver] backed by the configured silo.
-func (c *Config) NewDriver(context.Context) (*Driver, error) {
-	return New(c.Silo), nil
+// NewDriver returns a [Driver] described by the given configuration.
+func (c *Config) NewDriver(context.Context) (driver.Driver, error) {
+	return New(c), nil
 }
 
-// ParseURL returns a [*Config] for the given memory:// URL string.
+// ParseURL returns a [Config] for the given URL string.
 //
 // URL format:
 //
 //	memory:///<silo>
+//
+// The silo name identifies a shared in-memory store. Drivers with the same silo
+// name share state for the lifetime of the process.
 func ParseURL(ctx context.Context, u string) (*Config, error) {
 	parsed, err := url.Parse(u)
 	if err != nil {
@@ -59,8 +63,9 @@ func ParseURL(ctx context.Context, u string) (*Config, error) {
 	return FromURL(ctx, parsed)
 }
 
-// FromURL returns a [*Config] for the given memory:// [*url.URL]. See
-// [ParseURL] for the URL format.
+// FromURL returns a [Config] for the given URL.
+//
+// See [ParseURL] for the URL format.
 func FromURL(_ context.Context, u *url.URL) (*Config, error) {
 	if u.Scheme != "memory" {
 		return nil, fmt.Errorf("invalid memory URL: unexpected scheme %q", u.Scheme)

--- a/driver/memory/driver_test.go
+++ b/driver/memory/driver_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	ref := New("test-new")
+	ref := New(&Config{Silo: "test-new"})
 	t.Cleanup(func() {
 		ref.Close()
 	})
 
-	d := New("test-new")
+	d := New(&Config{Silo: "test-new"})
 	t.Cleanup(func() {
 		d.Close()
 	})
@@ -29,7 +29,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestParseURL(t *testing.T) {
-	ref := New("test-parse-url")
+	ref := New(&Config{Silo: "test-parse-url"})
 	t.Cleanup(func() {
 		ref.Close()
 	})
@@ -58,7 +58,7 @@ func TestParseURL(t *testing.T) {
 
 func TestFromURL(t *testing.T) {
 	t.Run("it returns a working driver", func(t *testing.T) {
-		ref := New("test-from-url")
+		ref := New(&Config{Silo: "test-from-url"})
 		t.Cleanup(func() {
 			ref.Close()
 		})

--- a/driver/sql/postgres/driver.go
+++ b/driver/sql/postgres/driver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/dogmatiq/persistencekit/driver"
 	"github.com/dogmatiq/persistencekit/driver/sql/postgres/pgjournal"
 	"github.com/dogmatiq/persistencekit/driver/sql/postgres/pgkv"
 	"github.com/dogmatiq/persistencekit/driver/sql/postgres/pgset"
@@ -22,21 +23,9 @@ type Driver struct {
 	db   *sql.DB
 }
 
-// New returns a [Driver] that uses the given [*sql.DB]. The caller retains
-// ownership of db; [Driver.Close] does not close it.
-func New(db *sql.DB) *Driver {
-	return &Driver{db: db}
-}
-
-// Config holds the configuration for a PostgreSQL persistence driver.
-type Config struct {
-	// Pool is the pgxpool configuration used to establish connections.
-	Pool *pgxpool.Config
-}
-
-// NewDriver creates a [Driver] backed by a new connection pool.
-func (c *Config) NewDriver(ctx context.Context) (*Driver, error) {
-	pool, err := pgxpool.NewWithConfig(ctx, c.Pool)
+// New returns a [Driver] described by the given configuration.
+func New(cfg *Config) (*Driver, error) {
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg.Pool)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +36,24 @@ func (c *Config) NewDriver(ctx context.Context) (*Driver, error) {
 	}, nil
 }
 
-// ParseURL returns a [*Config] for the given postgres:// or postgresql:// URL
-// string.
+// NewFromDB returns a [Driver] that uses the given [*sql.DB]. The caller
+// retains ownership of db; [Driver.Close] does not close it.
+func NewFromDB(db *sql.DB) *Driver {
+	return &Driver{db: db}
+}
+
+// Config holds the configuration for a PostgreSQL persistence driver.
+type Config struct {
+	// Pool is the pgxpool configuration used to establish connections.
+	Pool *pgxpool.Config
+}
+
+// NewDriver returns a [Driver] described by the given configuration.
+func (c *Config) NewDriver(context.Context) (driver.Driver, error) {
+	return New(c)
+}
+
+// ParseURL returns a [Config] for the given URL string.
 //
 // URL format:
 //
@@ -64,8 +69,9 @@ func ParseURL(ctx context.Context, u string) (*Config, error) {
 	return FromURL(ctx, parsed)
 }
 
-// FromURL returns a [*Config] for the given postgres:// or postgresql://
-// [*url.URL]. See [ParseURL] for the URL format.
+// FromURL returns a [Config] for the given URL.
+//
+// See [ParseURL] for the URL format.
 func FromURL(_ context.Context, u *url.URL) (*Config, error) {
 	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
 		return nil, fmt.Errorf("invalid postgres URL: unexpected scheme %q", u.Scheme)

--- a/driver/sql/postgres/driver_test.go
+++ b/driver/sql/postgres/driver_test.go
@@ -13,9 +13,34 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	db, dsn := pgtest.Setup(t)
+
+	cfg, err := postgres.ParseURL(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := postgres.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		d.Close()
+	})
+
+	drivertest.RunTests(
+		t,
+		d,
+		&pgjournal.BinaryStore{DB: db},
+		&pgkv.BinaryStore{DB: db},
+		&pgset.BinaryStore{DB: db},
+	)
+}
+
+func TestNewFromDB(t *testing.T) {
 	db, _ := pgtest.Setup(t)
 
-	d := postgres.New(db)
+	d := postgres.NewFromDB(db)
 	t.Cleanup(func() {
 		d.Close()
 	})


### PR DESCRIPTION
Move `Driver` and `Config` interfaces to the `driver` package so concrete configs can implement `Config` directly, without the generic `configAdapter` wrapper.

## Changes

- **`driver/driver.go` (new):** Central `Driver` and `Config` interfaces, importable by all concrete driver packages.
- **Root `driver.go`:** Type aliases (`Driver = driver.Driver`, `Config = driver.Config`) replace the old interface definitions. Removed `configAdapter` and `asInterface` generic wrapper. `FromURL` returns concrete results directly.
- **All driver packages:** `Config.NewDriver()` returns `driver.Driver` and forwards to the package-level `New()`.
- **`New()` signatures:** All take `*Config` consistently.
- **`NewFromDB` / `NewFromClient`:** Added for bring-your-own-resource paths (postgres, dynamodb, s3).
- **`postgres.New()`:** Uses `context.Background()` internally for `pgxpool.NewWithConfig` (only used for initial pool warm-up, defaults are zero).
- **Doc comments:** Normalized across all driver packages.